### PR TITLE
Upgrade Travis CI to use Nim v0.18.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,18 @@ dist: trusty
 
 language: c
 
+env:
+  - NIM_VERSION="0.18.0"
+
 install:
   - cd _test
-  - wget http://nim-lang.org/download/nim-0.14.2.tar.xz
-  - tar xf nim-0.14.2.tar.xz
-  - cd nim-0.14.2
+  - wget https://nim-lang.org/download/nim-$NIM_VERSION.tar.xz
+  - tar xf nim-$NIM_VERSION.tar.xz
+  - cd nim-$NIM_VERSION
   - ./build.sh
   - cd ../..
 
-before_script: export PATH=$PATH:$PWD/_test/nim-0.14.2/bin
+before_script: export PATH=$PATH:$PWD/_test/nim-$NIM_VERSION/bin
 
 script:
   - bin/fetch-configlet

--- a/exercises/anagram/example.nim
+++ b/exercises/anagram/example.nim
@@ -9,7 +9,7 @@ proc isAnagramTo(a, b: TAnagram): bool {.noSideEffect, procVar.} =
   a.chars == b.chars and cmpIgnoreCase(a.word, b.word) != 0
 
 proc anagram(word: string): TAnagram =
-  var chars = toSeq(word.toLower().items)
+  var chars = toSeq(word.toLowerAscii().items)
   sort(chars, cmp[char])
   (word, chars)
 

--- a/exercises/word-count/example.nim
+++ b/exercises/word-count/example.nim
@@ -6,12 +6,14 @@ type TWordCount* = CritBitTree[int]
 
 iterator words(s: string): string =
   for word in s.split(AllChars - Letters - Digits - {'\0'}):
-    yield toLower(word)
+    yield toLowerAscii(word)
 
 proc wordCount*(s: string): TWordCount {.noSideEffect.} =
   ## Returns a mapping from the words (alphanumeric sequences) in `s` to their
   ## respective counts.
   for word in words(s):
+    if word.len == 0:
+      continue
     if not result.hasKey(word):
       result[word] = 0
     result[word] = result[word] + 1


### PR DESCRIPTION
Updates `.travis.yml` to build with Nim v0.18.0 and fixes `toLower is deprecated` warnings