### PR TITLE
Adds blurb to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,15 +1,15 @@
 {
   "language": "Nim",
   "active": false,
-  "blurb": "",
+  "blurb": "Nim is a system and applications programming language that is statically typed and compiled, designed to be efficient, expressive, and elegant. Being general-purpose it can fill a wide range of uses but has found a niche in game development and systems programming including embedded systems.",
   "exercises": [
     {
       "slug": "hello-world",
       "uuid": "4817a6c0-6c9f-41ce-b53e-54ee3c0a6e40",
       "core": true,
+      "auto_approve": true,
       "unlocked_by": null,
       "difficulty": 1,
-      "auto_approve": true,
       "topics": [
         "conditionals",
         "optional_values",


### PR DESCRIPTION
For issue #86 to help with V2 launch, this adds a `blurb` to the `config.json` that will show up on the https://v2.exercism.io/tracks/nim in places of the `TODO`

![nim exercism 2018-06-28 12-10-03](https://user-images.githubusercontent.com/598958/42046627-4967fc6c-7acc-11e8-8162-18c00dd36d95.png)
