### PR TITLE
Set active to true for Nim Track

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "language": "Nim",
-  "active": false,
+  "active": true,
   "blurb": "Nim is a system and applications programming language that is statically typed and compiled, designed to be efficient, expressive, and elegant. Being general-purpose it can fill a wide range of uses but has found a niche in game development and systems programming including embedded systems.",
   "exercises": [
     {


### PR DESCRIPTION
I think after #98 (Updates to all the `README.md`) is merged, we are all set to turn `active` to `true` for the Nim track. This will close out the #13 (Launch planning). If there is something missing or something else that needs to happen let me know and I'll work on adding them to the track before merging this.