### PR TITLE
acronym: Update tests and example to 1.7.0, and fix warning

### DIFF
--- a/exercises/acronym/acronym_test.nim
+++ b/exercises/acronym/acronym_test.nim
@@ -1,20 +1,33 @@
 import unittest
-
 import acronym
 
+# version 1.7.0
+
 suite "Acronym":
-  
   test "basic":
     check abbreviate("Portable Network Graphics") == "PNG"
 
-  test "lowercase_words":
+  test "lowercase words":
     check abbreviate("Ruby on Rails") == "ROR"
 
   test "punctuation":
     check abbreviate("First In, First Out") == "FIFO"
-    
-  test "all_caps_words":
+
+  test "all caps word":
     check abbreviate("GNU Image Manipulation Program") == "GIMP"
 
-  test "punctuation_without_whitespace":
+  test "punctuation without whitespace":
     check abbreviate("Complementary metal-oxide semiconductor") == "CMOS"
+
+  test "very long abbreviation":
+    check abbreviate("Rolling On The Floor Laughing So Hard That " &
+                     "My Dogs Came Over And Licked Me") == "ROTFLSHTMDCOALM"
+
+  test "consecutive delimiters":
+    check abbreviate("Something - I made up from thin air") == "SIMUFTA"
+
+  test "apostrophes":
+    check abbreviate("Halley's Comet") == "HC"
+
+  test "underscore emphasis":
+    check abbreviate("The Road _Not_ Taken") == "TRNT"

--- a/exercises/acronym/example.nim
+++ b/exercises/acronym/example.nim
@@ -1,6 +1,5 @@
-import
-  strutils, sequtils 
+import re, sequtils, strutils
 
 proc abbreviate*(phrase: string): string =
-  let words = phrase.split({' ', '-', ','}).filterIt(it.isAlphaAscii)
+  let words = phrase.findall(re"[A-Z]+['a-z]*|['a-z]+")
   words.mapIt(it[0].toUpperAscii).join


### PR DESCRIPTION
`isAlphaAscii(s: string)` is deprecated in Nim 0.20, and the warning is shown in Nim 0.19. Note that `isAlphaAscii(c: char)` is not deprecated.

Reference: https://github.com/nim-lang/Nim/commit/7f81519f4114dbb49fcd68ca2361920bf374fb1c

If these pull requests are acceptable, I'd prefer if they were merged `fast-forward` if possible (that is, without an extra merge commit for each). Thanks.