### PR TITLE
space-age: Update tests to 1.2.0, and fix warning

### DIFF
--- a/exercises/space-age/example.nim
+++ b/exercises/space-age/example.nim
@@ -1,5 +1,4 @@
-import
-  math, tables
+import tables
 
 let
   times = {
@@ -14,4 +13,4 @@ let
   }.toTable
 
 proc age*(planet: string, seconds: int64): float =
-  round(seconds.float / times[planet], 2)
+  seconds.float / times[planet]

--- a/exercises/space-age/space_age_test.nim
+++ b/exercises/space-age/space_age_test.nim
@@ -1,29 +1,31 @@
 import unittest
-
 import space_age
 
 suite "Space Age":
+  # Helper operator: return true when two floats are approximately equal
+  func `~=`(x, y: float): bool =
+    abs(x - y) < 0.01
 
   test "age on Earth":
-    check age("Earth", 1000000000) == 31.69
-    
+    check age("Earth", 1_000_000_000) ~= 31.69
+
   test "age on Mercury":
-    check age("Mercury", 2134835688) == 280.88
+    check age("Mercury", 2_134_835_688) ~= 280.88
 
   test "age on Venus":
-    check age("Venus", 189839836) == 9.78
-    
+    check age("Venus", 189_839_836) ~= 9.78
+
   test "age on Mars":
-    check age("Mars", 2329871239) == 39.25
+    check age("Mars", 2_329_871_239) ~= 39.25
 
   test "age on Jupiter":
-    check age("Jupiter", 901876382) == 2.41
+    check age("Jupiter", 901_876_382) ~= 2.41
 
   test "age on Saturn":
-    check age("Saturn", 3000000000) == 3.23
+    check age("Saturn", 3_000_000_000) ~= 3.23
 
   test "age on Uranus":
-    check age("Uranus", 3210123456) == 1.21
+    check age("Uranus", 3_210_123_456) ~= 1.21
 
   test "age on Neptune":
-    check age("Neptune", 8210123456) == 1.58
+    check age("Neptune", 8_210_123_456) ~= 1.58

--- a/exercises/space-age/space_age_test.nim
+++ b/exercises/space-age/space_age_test.nim
@@ -1,6 +1,8 @@
 import unittest
 import space_age
 
+# version 1.2.0
+
 suite "Space Age":
   # Helper operator: return true when two floats are approximately equal
   func `~=`(x, y: float): bool =
@@ -16,16 +18,20 @@ suite "Space Age":
     check age("Venus", 189_839_836) ~= 9.78
 
   test "age on Mars":
-    check age("Mars", 2_329_871_239) ~= 39.25
+    check age("Mars", 2_129_871_239) ~= 35.88
 
   test "age on Jupiter":
     check age("Jupiter", 901_876_382) ~= 2.41
 
   test "age on Saturn":
-    check age("Saturn", 3_000_000_000) ~= 3.23
+    check age("Saturn", 2_000_000_000) ~= 2.15
 
   test "age on Uranus":
-    check age("Uranus", 3_210_123_456) ~= 1.21
+    check age("Uranus", 1_210_123_456) ~= 0.46
 
   test "age on Neptune":
-    check age("Neptune", 8_210_123_456) ~= 1.58
+    check age("Neptune", 1_821_023_456) ~= 0.35
+
+  # Bonus
+  test "age that requires int64":
+    check age("Saturn", 3_000_000_000) ~= 3.23


### PR DESCRIPTION
Float comparison should be performed without rounding, and `round(x: float, places: int)` is deprecated in Nim 0.19. Note that `round(x: float)` is not deprecated.

Nim reference: https://github.com/nim-lang/Nim/commit/5076fda2e25a7f14dac130b591de6cc1eebfcc06

Upstream: https://github.com/exercism/problem-specifications/pull/1441
The numbers were changed to fit within a 32-bit int range.