### PR TITLE
Travis CI: Update to 16.04 Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 
 language: c
 


### PR DESCRIPTION
14.04 Trusty reaches End-of-Life in April 2019.

(18.04 Bionic is not yet available on Travis).