### PR TITLE
Implement exercise: darts

### DIFF
--- a/config.json
+++ b/config.json
@@ -409,6 +409,18 @@
       ]
     },
     {
+      "slug": "darts",
+      "uuid": "c83824af-bac6-4e59-9bf0-df5ab3f83a3d",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "conditionals",
+        "floating_point_numbers",
+        "math"
+      ]
+    },
+    {
       "slug": "secret-handshake",
       "uuid": "09623b3d-05ee-4825-aae8-6434c9538366",
       "core": false,

--- a/exercises/darts/README.md
+++ b/exercises/darts/README.md
@@ -1,0 +1,46 @@
+# Darts
+
+Write a function that returns the earned points in a single toss of a Darts game.
+
+[Darts](https://en.wikipedia.org/wiki/Darts) is a game where players
+throw darts to a [target](https://en.wikipedia.org/wiki/Darts#/media/File:Darts_in_a_dartboard.jpg).
+
+In our particular instance of the game, the target rewards with 4 different amounts of points, depending on where the dart lands:
+
+* If the dart lands outside the target, player earns no points (0 points).
+* If the dart lands in the outer circle of the target, player earns 1 point.
+* If the dart lands in the middle circle of the target, player earns 5 points.
+* If the dart lands in the inner circle of the target, player earns 10 points.
+
+The outer circle has a radius of 10 units (This is equivalent to the total radius for the entire target), the middle circle a radius of 5 units, and the inner circle a radius of 1. Of course, they are all centered to the same point (That is, the circles are [concentric](http://mathworld.wolfram.com/ConcentricCircles.html)) defined by the coordinates (0, 0).
+
+Write a function that given a point in the target (defined by its `real` cartesian coordinates `x` and `y`), returns the correct amount earned by a dart landing in that point.
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r darts_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/darts` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Inspired by an excersie created by a professor Della Paolera in Argentina
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/darts/darts_test.nim
+++ b/exercises/darts/darts_test.nim
@@ -1,0 +1,26 @@
+import unittest
+import darts
+
+# version 1.1.0
+
+suite "Darts":
+  test "A dart lands outside the target":
+    check score((-9.0, 9.0)) == 0
+
+  test "A dart lands just in the border of the target":
+    check score((0.0, 10.0)) == 1
+
+  test "A dart lands in the outer circle":
+    check score((4.0, 4.0)) == 1
+
+  test "A dart lands right in the border between outer and middle circles":
+    check score((5.0, 0.0)) == 5
+
+  test "A dart lands in the middle circle":
+    check score((0.8, -0.8)) == 5
+
+  test "A dart lands right in the border between middle and inner circles":
+    check score((0.0, -1.0)) == 10
+
+  test "A dart lands in the inner circle":
+    check score((-0.1, -0.1)) == 10

--- a/exercises/darts/example.nim
+++ b/exercises/darts/example.nim
@@ -1,0 +1,12 @@
+import math
+
+func score*(p: tuple[x, y: float]): int =
+  let r = hypot(p.x, p.y)
+  if r <= 1:
+    10
+  elif r <= 5:
+    5
+  elif r <= 10:
+    1
+  else:
+    0


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/darts/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/darts/canonical-data.json)


### General notes
I'll set the other PRs to the new "draft" mode until I have time to comment on any implementation details in the PR description.

For simplicity, in `config.json` I added all new exercises after `react`, and set `unlocked_by` to `null`. So for now, I suggest merging the new exercises into `config.json` below `react` and around `secret-handshake`, in alphabetical order.

Alphabetical order could also help reduce the diff noise later if [this suggested config.json ordering](https://github.com/exercism/configlet/issues/152#issuecomment-449981969) becomes the default.

After adding this wave of exercises we could consider whether any of the new exercises should be `core`, and change the track structure accordingly.

Thanks.