### PR TITLE
Implement exercise: etl

### DIFF
--- a/config.json
+++ b/config.json
@@ -421,6 +421,17 @@
       ]
     },
     {
+      "slug": "etl",
+      "uuid": "da9807c2-959d-49e0-86a9-44de02501f37",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "maps",
+        "transforming"
+      ]
+    },
+    {
       "slug": "secret-handshake",
       "uuid": "09623b3d-05ee-4825-aae8-6434c9538366",
       "core": false,

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -1,0 +1,77 @@
+# ETL
+
+We are going to do the `Transform` step of an Extract-Transform-Load.
+
+### ETL
+
+Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so
+we're going to migrate this."
+
+(Typically, this is followed by, "We're only going to need to run this
+once." That's then typically followed by much forehead slapping and
+moaning about how stupid we could possibly be.)
+
+### The goal
+
+We're going to extract some scrabble scores from a legacy system.
+
+The old system stored a list of letters per score:
+
+- 1 point: "A", "E", "I", "O", "U", "L", "N", "R", "S", "T",
+- 2 points: "D", "G",
+- 3 points: "B", "C", "M", "P",
+- 4 points: "F", "H", "V", "W", "Y",
+- 5 points: "K",
+- 8 points: "J", "X",
+- 10 points: "Q", "Z",
+
+The shiny new scrabble system instead stores the score per letter, which
+makes it much faster and easier to calculate the score for a word. It
+also stores the letters in lower-case regardless of the case of the
+input letters:
+
+- "a" is worth 1 point.
+- "b" is worth 3 points.
+- "c" is worth 3 points.
+- "d" is worth 2 points.
+- Etc.
+
+Your mission, should you choose to accept it, is to transform the legacy data
+format to the shiny new format.
+
+### Notes
+
+A final note about scoring, Scrabble is played around the world in a
+variety of languages, each with its own unique scoring table. For
+example, an "E" is scored at 2 in the Māori-language version of the
+game while being scored at 4 in the Hawaiian-language version.
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r etl_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/etl` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+The Jumpstart Lab team [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/etl/etl_test.nim
+++ b/exercises/etl/etl_test.nim
@@ -1,0 +1,80 @@
+import unittest, tables
+import etl
+
+# version 1.0.0
+
+suite "ETL":
+  test "a single score with a single letter":
+    const input = {
+      1: @['A']
+    }.toTable
+    let output = transform(input)
+    check:
+      output.len == 1
+      output['a'] == 1
+
+  test "a single score with multiple letters":
+    const input = {
+      1: @['A', 'E', 'I', 'O', 'U']
+    }.toTable
+    let output = transform(input)
+    check:
+      output.len == 5
+      output['a'] == 1
+      output['e'] == 1
+      output['i'] == 1
+      output['o'] == 1
+      output['u'] == 1
+
+  test "multiple scores with multiple letters":
+    const input = {
+      1: @['A', 'E'],
+      2: @['D', 'G']
+    }.toTable
+    let output = transform(input)
+    check:
+      output.len == 4
+      output['a'] == 1
+      output['e'] == 1
+      output['d'] == 2
+      output['g'] == 2
+
+  test "multiple scores with differing numbers of letters":
+    const input = {
+      1: @['A', 'E', 'I', 'O', 'U', 'L', 'N', 'R', 'S', 'T'],
+      2: @['D', 'G'],
+      3: @['B', 'C', 'M', 'P'],
+      4: @['F', 'H', 'V', 'W', 'Y'],
+      5: @['K'],
+      8: @['J', 'X'],
+      10: @['Q', 'Z']
+    }.toTable
+    let output = transform(input)
+    check:
+      output.len == 26
+      output['a'] == 1
+      output['b'] == 3
+      output['c'] == 3
+      output['d'] == 2
+      output['e'] == 1
+      output['f'] == 4
+      output['g'] == 2
+      output['h'] == 4
+      output['i'] == 1
+      output['j'] == 8
+      output['k'] == 5
+      output['l'] == 1
+      output['m'] == 3
+      output['n'] == 1
+      output['o'] == 1
+      output['p'] == 3
+      output['q'] == 10
+      output['r'] == 1
+      output['s'] == 1
+      output['t'] == 1
+      output['u'] == 1
+      output['v'] == 4
+      output['w'] == 4
+      output['x'] == 8
+      output['y'] == 4
+      output['z'] == 10

--- a/exercises/etl/example.nim
+++ b/exercises/etl/example.nim
@@ -1,0 +1,8 @@
+import strutils, tables
+
+func transform*(t: Table[int, seq[char]]): Table[char, int] =
+  result = initTable[char, int]()
+
+  for score, letters in t:
+    for c in letters:
+      result[c.toLowerAscii] = score


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/etl/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/etl/canonical-data.json)


### Implementation details
The tests are verbose so that the user's solution can return any hash table type (`Table`, `OrderedTable`, `CountTable`, `TableRef`, `OrderedTableRef`, `CountTableRef`).

I think this way is the most clear to a student. If we change the approach, then we should also change it for other exercises that use `tables`.

There is currently a `hints.md` file for `word-count`. When we restructure the track, we should move this hint to the easiest exercise that uses `tables`.


#### Alternative approaches:
1. Require that the solution uses an arbitrary hash table type, e.g. `Table`:
```Nim
  test "multiple scores with multiple letters":
    const input = {
      1: @['A', 'E'],
      2: @['D', 'G']
    }.toTable
    const expected = {
      'a': 1, 'd': 2, 'e': 1, 'g': 2
    }.ToTable
    let output = transform(input)
    check output == expected
```

2. Compare key/value pairs, for example:
```Nim
  test "multiple scores with multiple letters":
    const input = {
      1: @['A', 'E'],
      2: @['D', 'G']
    }.toTable
    const expected = {
      'a': 1, 'd': 2, 'e': 1, 'g': 2
    }
    let output = transform(input)
    # Just for fun: the new tuple unpacking syntax
    for (c, score) in expected:
      check output[c] == score
```

For `etl`, this is only significantly less verbose for the final test.
