### PR TITLE
Implement exercise: high-scores

### DIFF
--- a/config.json
+++ b/config.json
@@ -432,6 +432,17 @@
       ]
     },
     {
+      "slug": "high-scores",
+      "uuid": "957a8f39-1c9e-43ef-917c-d70278314278",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "sequences",
+        "sorting"
+      ]
+    },
+    {
       "slug": "secret-handshake",
       "uuid": "09623b3d-05ee-4825-aae8-6434c9538366",
       "core": false,

--- a/exercises/high-scores/README.md
+++ b/exercises/high-scores/README.md
@@ -1,0 +1,35 @@
+# High Scores
+
+Manage a game player's High Score list.
+
+Your task is to build a high-score component of the classic Frogger game, one of the highest selling and addictive games of all time, and a classic of the arcade era. Your task is to write methods that return the highest score from the list, the last added score and the three highest scores.
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r high_scores_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/high-scores` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Tribute to the eighties' arcade game Frogger
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/high-scores/example.nim
+++ b/exercises/high-scores/example.nim
@@ -1,0 +1,10 @@
+import algorithm
+
+func latest*(scores: openArray[int]): int =
+  scores[^1]
+
+func personalBest*(scores: openArray[int]): int =
+  scores.max
+
+func personalTopThree*(scores: openArray[int]): seq[int] =
+  scores.sorted(cmp = system.cmp, order = Descending)[0 .. min(2, scores.high)]

--- a/exercises/high-scores/high_scores_test.nim
+++ b/exercises/high-scores/high_scores_test.nim
@@ -1,0 +1,27 @@
+import unittest
+import high_scores
+
+# version 4.0.0
+
+suite "High Scores":
+  test "latest score":
+    check latest(@[100, 0, 90, 30]) == 30
+
+  test "personal best":
+    check personalBest(@[40, 100, 70]) == 100
+
+  test "personal top three from a list of scores":
+    check personalTopThree(@[10, 30, 90, 30, 100, 20,
+                             10, 0, 30, 40, 40, 70, 70]) == @[100, 90, 70]
+
+  test "personal top highest to lowest":
+    check personalTopThree(@[20, 10, 30]) == @[30, 20, 10]
+
+  test "personal top when there is a tie":
+    check personalTopThree(@[40, 20, 40, 30]) == @[40, 40, 30]
+
+  test "personal top when there are less than 3":
+    check personalTopThree(@[30, 70]) == @[70, 30]
+
+  test "personal top when there is only one":
+    check personalTopThree(@[40]) == @[40]


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/high-scores/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/high-scores/canonical-data.json)


### Implementation details
The input is implemented as `seq`, not `array`. Nim students should know about `openArray`, but let's not insist on it for this exercise.

In Nim 0.19.4, `sort` and `sorted` require the `cmp` parameter. It [won't be needed](https://nim-lang.github.io/Nim/algorithm.html#sorted,openArray[T]) in Nim 0.20.

Other tracks use `high-scores` as a `core` exercise to introduce classes. But there are more appropriate exercises for introducing `object`, `type` or `tuple` in Nim.

Our approach should more similar to that of, for example, [the F# track](https://github.com/exercism/fsharp/blob/master/exercises/high-scores).

Right now, I don't consider it "in scope" to manually edit the auto-generated `README.md`. But the `high-scores` one contains:

> "Your task is to write methods that return the highest score from the list".

This sounds strange for Nim. I changed the word "methods" to "procedures".

See:
- [Nim Manual - Procedures](https://nim-lang.github.io/Nim/manual.html#procedures)
- [Nim Tutorial (Part II) - Methods](https://nim-lang.org/docs/tut2.html#object-oriented-programming-methods)