### PR TITLE
Implement exercise: isbn-verifier

### DIFF
--- a/config.json
+++ b/config.json
@@ -443,6 +443,18 @@
       ]
     },
     {
+      "slug": "isbn-verifier",
+      "uuid": "e184b588-f6a1-4e07-ab31-5cedfd4f26c7",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "parsing",
+        "strings",
+        "type_conversion"
+      ]
+    },
+    {
       "slug": "secret-handshake",
       "uuid": "09623b3d-05ee-4825-aae8-6434c9538366",
       "core": false,

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -1,0 +1,71 @@
+# ISBN Verifier
+
+The [ISBN-10 verification process](https://en.wikipedia.org/wiki/International_Standard_Book_Number) is used to validate book identification
+numbers. These normally contain dashes and look like: `3-598-21508-8`
+
+## ISBN
+
+The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
+
+```
+(x1 * 10 + x2 * 9 + x3 * 8 + x4 * 7 + x5 * 6 + x6 * 5 + x7 * 4 + x8 * 3 + x9 * 2 + x10 * 1) mod 11 == 0
+```
+
+If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
+
+## Example
+
+Let's take the ISBN-10 `3-598-21508-8`. We plug it in to the formula, and get:
+```
+(3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
+```
+
+Since the result is 0, this proves that our ISBN is valid.
+
+## Task
+
+Given a string the program should check if the provided string is a valid ISBN-10.
+Putting this into place requires some thinking about preprocessing/parsing of the string prior to calculating the check digit for the ISBN.
+
+The program should be able to verify ISBN-10 both with and without separating dashes.
+
+
+## Caveats
+
+Converting from strings to numbers can be tricky in certain languages.
+Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10'). For instance `3-598-21507-X` is a valid ISBN-10.
+
+## Bonus tasks
+
+* Generate a valid ISBN-13 from the input ISBN-10 (and maybe verify it again with a derived verifier).
+
+* Generate valid ISBN, maybe even from a given starting ISBN.
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r isbn_verifier_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/isbn-verifier` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Converting a string into a number and some basic processing utilizing a relatable real world example. [https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation](https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/isbn-verifier/example.nim
+++ b/exercises/isbn-verifier/example.nim
@@ -1,0 +1,18 @@
+func isValid*(s: string): bool =
+  var digitCount = 0
+  var sum = 0
+  var n = 10
+
+  for i, c in s:
+    if c in {'0'..'9'}:
+      sum += (c.ord - '0'.ord) * n
+    elif c == 'X' and i == s.high:
+      sum += 10 * n
+    elif c == '-':
+      continue
+    else:
+      return false
+    dec n
+    inc digitCount
+
+  sum mod 11 == 0 and digitCount == 10

--- a/exercises/isbn-verifier/isbn_verifier_test.nim
+++ b/exercises/isbn-verifier/isbn_verifier_test.nim
@@ -1,0 +1,56 @@
+import unittest
+import isbn_verifier
+
+# version 2.7.0
+
+suite "ISBN Verifier":
+  test "valid ISBN":
+    check isValid("3-598-21508-8") == true
+
+  test "invalid ISBN check digit":
+    check isValid("3-598-21508-9") == false
+
+  test "valid ISBN with a check digit of 10":
+    check isValid("3-598-21507-X") == true
+
+  test "check digit is a character other than X":
+    check isValid("3-598-21507-A") == false
+
+  test "invalid character in ISBN":
+    check isValid("3-598-P1581-X") == false
+
+  test "X is only valid as a check digit":
+    check isValid("3-598-2X507-9") == false
+
+  test "valid ISBN without separating dashes":
+    check isValid("3598215088") == true
+
+  test "ISBN without separating dashes and X as check digit":
+    check isValid("359821507X") == true
+
+  test "ISBN without check digit and dashes":
+    check isValid("359821507") == false
+
+  test "too long ISBN and no dashes":
+    check isValid("3598215078X") == false
+
+  test "too short ISBN":
+    check isValid("00") == false
+
+  test "ISBN without check digit":
+    check isValid("3-598-21507") == false
+
+  test "check digit of X should not be used for 0":
+    check isValid("3-598-21515-X") == false
+
+  test "empty ISBN":
+    check isValid("") == false
+
+  test "input is 9 characters":
+    check isValid("134456729") == false
+
+  test "invalid characters are not ignored":
+    check isValid("3132P34035") == false
+
+  test "input is too long but contains a valid ISBN":
+    check isValid("98245726788") == false


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/isbn-verifier/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/isbn-verifier/canonical-data.json)


### Implementation details
The example solution illustrates a fast, imperative approach that uses only one loop over the input. Other common approaches might use regular expressions, `strutils.replace`, or `sequtils`.

For clarity, let's keep using the style
- `check a == true`
- `check b == false`

rather than the equivalent
- `check a`
- `check not b`