### PR TITLE
Implement exercise: kindergarten-garden

### DIFF
--- a/config.json
+++ b/config.json
@@ -455,6 +455,18 @@
       ]
     },
     {
+      "slug": "kindergarten-garden",
+      "uuid": "3df571f3-e47f-469b-b427-ac0f5167f964",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "enumerations",
+        "parsing",
+        "strings"
+      ]
+    },
+    {
       "slug": "secret-handshake",
       "uuid": "09623b3d-05ee-4825-aae8-6434c9538366",
       "core": false,

--- a/exercises/kindergarten-garden/README.md
+++ b/exercises/kindergarten-garden/README.md
@@ -1,0 +1,90 @@
+# Kindergarten Garden
+
+Given a diagram, determine which plants each child in the kindergarten class is
+responsible for.
+
+The kindergarten class is learning about growing plants. The teacher
+thought it would be a good idea to give them actual seeds, plant them in
+actual dirt, and grow actual plants.
+
+They've chosen to grow grass, clover, radishes, and violets.
+
+To this end, the children have put little cups along the window sills, and
+planted one type of plant in each cup, choosing randomly from the available
+types of seeds.
+
+```text
+[window][window][window]
+........................ # each dot represents a cup
+........................
+```
+
+There are 12 children in the class:
+
+- Alice, Bob, Charlie, David,
+- Eve, Fred, Ginny, Harriet,
+- Ileana, Joseph, Kincaid, and Larry.
+
+Each child gets 4 cups, two on each row. Their teacher assigns cups to
+the children alphabetically by their names.
+
+The following diagram represents Alice's plants:
+
+```text
+[window][window][window]
+VR......................
+RG......................
+```
+
+In the first row, nearest the windows, she has a violet and a radish.  In the
+second row she has a radish and some grass.
+
+Your program will be given the plants from left-to-right starting with
+the row nearest the windows. From this, it should be able to determine
+which plants belong to each student.
+
+For example, if it's told that the garden looks like so:
+
+```text
+[window][window][window]
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+```
+
+Then if asked for Alice's plants, it should provide:
+
+- Violets, radishes, violets, radishes
+
+While asking for Bob's plants would yield:
+
+- Clover, grass, clover, clover
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r kindergarten_garden_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/kindergarten-garden` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Random musings during airplane trip. [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/kindergarten-garden/example.nim
+++ b/exercises/kindergarten-garden/example.nim
@@ -1,0 +1,18 @@
+type Plant* = enum
+  Clover, Grass, Radishes, Violets
+
+func plants*(s: string, student: string): seq[Plant] =
+  # Use the first letter of a student's name to find their plants.
+  # i: The index of their first plant in the first row.
+  # j: The index of their first plant in the second row.
+  let i = 2 * (student[0].ord - 'A'.ord)
+  let j = (s.high div 2) + 1 + i
+  let theirPlants = s[i .. i+1] & s[j .. j+1]
+
+  for c in theirPlants:
+    case c
+    of 'C': result &= Clover
+    of 'G': result &= Grass
+    of 'R': result &= Radishes
+    of 'V': result &= Violets
+    else: raise newException(ValueError, "Invalid plant: " & $c)

--- a/exercises/kindergarten-garden/kindergarten_garden_test.nim
+++ b/exercises/kindergarten-garden/kindergarten_garden_test.nim
@@ -1,0 +1,49 @@
+import unittest
+import kindergarten_garden
+
+# version 1.1.1
+
+suite "Kindergarten Garden":
+  test "partial garden: garden with single student":
+    const garden = "RC\n" &
+                   "GG"
+    check plants(garden, "Alice") == @[Radishes, Clover, Grass, Grass]
+
+  test "partial garden: different garden with single student":
+    const garden = "VC\n" &
+                   "RC"
+    check plants(garden, "Alice") == @[Violets, Clover, Radishes, Clover]
+
+  test "partial garden: garden with two students":
+    const garden = "VVCG\n" &
+                   "VVRC"
+    check plants(garden, "Bob") == @[Clover, Grass, Radishes, Clover]
+
+
+  # Test multiple students for the same 3-student garden.
+  const smallGarden = "VVCCGG\n" &
+                      "VVCCGG"
+
+  test "partial garden: garden with three students - second student's garden":
+    check plants(smallGarden, "Bob") == @[Clover, Clover, Clover, Clover]
+
+  test "partial garden: garden with three students - third student's garden":
+    check plants(smallGarden, "Charlie") == @[Grass, Grass, Grass, Grass]
+
+
+  # Test multiple students for the same 12-student garden.
+  const fullGarden = "VRCGVVRVCGGCCGVRGCVCGCGV\n" &
+                     "VRCCCGCRRGVCGCRVVCVGCGCV"
+
+  test "full garden: first student's garden":
+    check plants(fullGarden, "Alice") == @[Violets, Radishes,
+                                           Violets, Radishes]
+
+  test "full garden: second student's garden":
+    check plants(fullGarden, "Bob") == @[Clover, Grass, Clover, Clover]
+
+  test "full garden: second to last student's garden":
+    check plants(fullGarden, "Kincaid") == @[Grass, Clover, Clover, Grass]
+
+  test "full garden: last student's garden":
+    check plants(fullGarden, "Larry") == @[Grass, Violets, Clover, Violets]


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/kindergarten-garden/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/kindergarten-garden/canonical-data.json)


### Implementation details
The return type is implemented as a `seq`. Returning `array` for this exercise feels somewhat like "overfitting", but that will also pass the tests. That is, `[1, 2] == @[1, 2]` is [true](https://nim-lang.github.io/Nim/system.html#%3D%3D%2CopenArray%5BT%5D%2CopenArray%5BT%5D).

I define `smallGarden` and `fullGarden` for the tests with common input, and for now only use one `suite`. But it's debatable; maybe some track-wide convention for using multiple `suite` statements will become more obvious later. I think it feels a bit overkill here.

Some tracks like [python](https://github.com/exercism/python/blob/master/exercises/kindergarten-garden/kindergarten_garden_test.py) are a bit more liberal with grouping the tests from the canonical data, but I ended up just using the "partial garden" test name prefixing from [F#](https://github.com/exercism/fsharp/blob/master/exercises/kindergarten-garden/KindergartenGardenTest.fs).

#### Track restructuring
This is the first exercise to be added that uses `enum`. Later, we could consider setting the "easiest" `enum` exercise as `core`, and add a `hints.md` file for it.