### PR TITLE
Implement exercise: largest-series-product

### DIFF
--- a/config.json
+++ b/config.json
@@ -467,6 +467,19 @@
       ]
     },
     {
+      "slug": "largest-series-product",
+      "uuid": "6491e319-9bb9-4e02-8048-77598c0c7b98",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "algorithms",
+        "integers",
+        "math",
+        "strings"
+      ]
+    },
+    {
       "slug": "secret-handshake",
       "uuid": "09623b3d-05ee-4825-aae8-6434c9538366",
       "core": false,

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -1,0 +1,44 @@
+# Largest Series Product
+
+Given a string of digits, calculate the largest product for a contiguous
+substring of digits of length n.
+
+For example, for the input `'1027839564'`, the largest product for a
+series of 3 digits is 270 (9 * 5 * 6), and the largest product for a
+series of 5 digits is 7560 (7 * 8 * 3 * 9 * 5).
+
+Note that these series are only required to occupy *adjacent positions*
+in the input; the digits need not be *numerically consecutive*.
+
+For the input `'73167176531330624919225119674426574742355349194934'`,
+the largest product for a series of 6 digits is 23520.
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r largest_series_product_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/largest-series-product` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+A variation on Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/largest-series-product/example.nim
+++ b/exercises/largest-series-product/example.nim
@@ -1,0 +1,31 @@
+func toInt(c: char): int =
+  ord(c) - ord('0')
+
+func largestProduct*(s: string, span: int): int =
+  if span > s.len or span < 0:
+    raise newException(ValueError, "Invalid span: " & $span)
+  if s.len == 0:
+    return 1
+
+  var product = 1
+  var nZeros = 0
+
+  for i, c in s:
+    if c notin {'0'..'9'}:
+      raise newException(ValueError, "Invalid character: " & c)
+
+    if i >= span:
+      let tail = toInt(s[i - span])
+      if tail == 0:
+        nZeros -= 1
+      else:
+        product = product div tail
+
+    let head = toInt(c)
+    if head == 0:
+      nZeros += 1
+    else:
+      product *= head
+
+    if nZeros == 0 and i >= span-1:
+      result = max(result, product)

--- a/exercises/largest-series-product/largest_series_product_test.nim
+++ b/exercises/largest-series-product/largest_series_product_test.nim
@@ -1,0 +1,79 @@
+import unittest
+import largest_series_product
+
+# version 1.2.0
+
+suite "Largest Series Product":
+  test "finds the largest product if span equals length":
+    check largestProduct("29", 2) == 18
+
+  test "finds the largest product of 2 with numbers in order":
+    check largestProduct("0123456789", 2) == 72
+
+  test "finds the largest product of 2":
+    check largestProduct("576802143", 2) == 48
+
+  test "finds the largest product of 3 with numbers in order":
+    check largestProduct("0123456789", 3) == 504
+
+  test "finds the largest product of 3":
+    check largestProduct("1027839564", 3) == 270
+
+  test "finds the largest product of 5 with numbers in order":
+    check largestProduct("0123456789", 5) == 15_120
+
+  test "finds the largest product of a big number":
+    check largestProduct("73167176531330624919225119674426574742355349194934",
+                         6) == 23_520
+
+  test "reports zero if the only digits are zero":
+    check largestProduct("0000", 2) == 0
+
+  test "reports zero if all spans include zero":
+    check largestProduct("99099", 3) == 0
+
+  test "rejects span longer than string length":
+    expect ValueError:
+      discard largestProduct("123", 4)
+
+  test "reports 1 for empty string and empty product (0 span)":
+    check largestProduct("", 0) == 1
+
+  test "reports 1 for nonempty string and empty product (0 span)":
+    check largestProduct("123", 0) == 1
+
+  test "rejects empty string and nonzero span":
+    expect ValueError:
+      discard largestProduct("", 1)
+
+  test "rejects invalid character in digits":
+    expect ValueError:
+      discard largestProduct("1234a5", 2)
+
+  test "rejects negative span":
+    expect ValueError:
+      discard largestProduct("12345", -1)
+
+  # Bonus
+  test "big number from Project Euler problem 8":
+    const n = "73167176531330624919225119674426574742355349194934" &
+              "96983520312774506326239578318016984801869478851843" &
+              "85861560789112949495459501737958331952853208805511" &
+              "12540698747158523863050715693290963295227443043557" &
+              "66896648950445244523161731856403098711121722383113" &
+              "62229893423380308135336276614282806444486645238749" &
+              "30358907296290491560440772390713810515859307960866" &
+              "70172427121883998797908792274921901699720888093776" &
+              "65727333001053367881220235421809751254540594752243" &
+              "52584907711670556013604839586446706324415722155397" &
+              "53697817977846174064955149290862569321978468622482" &
+              "83972241375657056057490261407972968652414535100474" &
+              "82166370484403199890008895243450658541227588666881" &
+              "16427171479924442928230863465674813919123162824586" &
+              "17866458359124566529476545682848912883142607690042" &
+              "24219022671055626321111109370544217506941658960408" &
+              "07198403850962455444362981230987879927244284909188" &
+              "84580156166097919133875499200524063689912560717606" &
+              "05886116467109405077541002256983155200055935729725" &
+              "71636269561882670428252483600823257530420752963450"
+    check largestProduct(n, 13) == 23_514_624_000


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/largest-series-product/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/largest-series-product/canonical-data.json)


### Implementation details
A bonus test is included.

There are some exercises where we can consider giving the user some practice with the [`options`](https://nim-lang.github.io/Nim/options.html) module, but I don't think `largest-series-product` is a good first candidate.

The example solution can be much shorter, but this is one exercise where it might interest the user to write a more efficient solution. This commit's `example.nim` uses at most:
- one multiplication per input digit
- one integer division per slice

and takes advantage of zeros.

One possible naive solution computes the product from scratch for every slice. For example:

```Nim
func largestProduct*(s: string, span: int): int =
  if span > s.len or span < 0:
    raise newException(ValueError, "Invalid span: " & $span)

  for i in 0 .. s.len - span:
    var product = 1
    let slice = s[i ..< i+span]
    for i, c in slice:
      if c in {'0'..'9'}:
        product *= ord(c) - ord('0')
      else:
        raise newException(ValueError, "Invalid character: " & c)
    result = max(result, product)
```

This performs `(slice length) * (number of slices)` multiplications.