### PR TITLE
Implement exercise: luhn

### DIFF
--- a/config.json
+++ b/config.json
@@ -480,6 +480,18 @@
       ]
     },
     {
+      "slug": "luhn",
+      "uuid": "a8de14a7-aa77-4e5e-83cd-fa4321dd7a36",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "algorithms",
+        "integers",
+        "strings"
+      ]
+    },
+    {
       "slug": "secret-handshake",
       "uuid": "09623b3d-05ee-4825-aae8-6434c9538366",
       "core": false,

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -1,0 +1,95 @@
+# Luhn
+
+Given a number determine whether or not it is valid per the Luhn formula.
+
+The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is
+a simple checksum formula used to validate a variety of identification
+numbers, such as credit card numbers and Canadian Social Insurance
+Numbers.
+
+The task is to check if a given string is valid.
+
+Validating a Number
+------
+
+Strings of length 1 or less are not valid. Spaces are allowed in the input,
+but they should be stripped before checking. All other non-digit characters
+are disallowed.
+
+## Example 1: valid credit card number
+
+```text
+4539 1488 0343 6467
+```
+
+The first step of the Luhn algorithm is to double every second digit,
+starting from the right. We will be doubling
+
+```text
+4_3_ 1_8_ 0_4_ 6_6_
+```
+
+If doubling the number results in a number greater than 9 then subtract 9
+from the product. The results of our doubling:
+
+```text
+8569 2478 0383 3437
+```
+
+Then sum all of the digits:
+
+```text
+8+5+6+9+2+4+7+8+0+3+8+3+3+4+3+7 = 80
+```
+
+If the sum is evenly divisible by 10, then the number is valid. This number is valid!
+
+## Example 2: invalid credit card number
+
+```text
+8273 1232 7352 0569
+```
+
+Double the second digits, starting from the right
+
+```text
+7253 2262 5312 0539
+```
+
+Sum the digits
+
+```text
+7+2+5+3+2+2+6+2+5+3+1+2+0+5+3+9 = 57
+```
+
+57 is not evenly divisible by 10, so this number is not valid.
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r luhn_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/luhn` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+The Luhn Algorithm on Wikipedia [http://en.wikipedia.org/wiki/Luhn_algorithm](http://en.wikipedia.org/wiki/Luhn_algorithm)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/luhn/example.nim
+++ b/exercises/luhn/example.nim
@@ -1,0 +1,24 @@
+func createLookup: array[10, int] =
+  for i in 0 .. result.high:
+    let d = 2 * i
+    result[i] = if d > 9: d - 9 else: d
+
+const lookup = createLookup() # Create lookup at compile-time.
+
+func isValid*(s: string): bool =
+  var toDouble = false
+  var sum = 0
+  var nDigits = 0
+
+  for i in countdown(s.high, 0):
+    if s[i] in {'0'..'9'}:
+      let digit = s[i].ord - '0'.ord
+      sum += (if toDouble: lookup[digit] else: digit)
+      nDigits += 1
+      toDouble = not toDouble
+    elif s[i] == ' ':
+      discard
+    else:
+      return false
+
+  sum mod 10 == 0 and nDigits > 1

--- a/exercises/luhn/luhn_test.nim
+++ b/exercises/luhn/luhn_test.nim
@@ -1,0 +1,53 @@
+import unittest
+import luhn
+
+# version 1.4.0
+
+suite "Luhn":
+  test "single digit strings can not be valid":
+    check isValid("1") == false
+
+  test "a single zero is invalid":
+    check isValid("0") == false
+
+  test "a simple valid SIN that remains valid if reversed":
+    check isValid("059") == true
+
+  test "a simple valid SIN that becomes invalid if reversed":
+    check isValid("59") == true
+
+  test "a valid Canadian SIN":
+    check isValid("055 444 285") == true
+
+  test "invalid Canadian SIN":
+    check isValid("055 444 286") == false
+
+  test "invalid credit card":
+    check isValid("8273 1232 7352 0569") == false
+
+  test "valid number with an even number of digits":
+    check isValid("095 245 88") == true
+
+  test "valid strings with a non-digit included become invalid":
+    check isValid("055a 444 285") == false
+
+  test "valid strings with a non-digit added at the end become invalid":
+    check isValid("059a") == false
+
+  test "valid strings with punctuation included become invalid":
+    check isValid("055-444-285") == false
+
+  test "valid strings with symbols included become invalid":
+    check isValid("055£ 444$ 285") == false
+
+  test "single zero with space is invalid":
+    check isValid(" 0") == false
+
+  test "more than a single zero is valid":
+    check isValid("0000 0") == true
+
+  test "input digit 9 is correctly converted to output digit 9":
+    check isValid("091") == true
+
+  test "strings with non-digits is invalid":
+    check isValid(":9") == false


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/luhn/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/luhn/canonical-data.json)


### Comments
The example solution creates a lookup at compile-time for the "double or double minus 9" rule, and uses only one loop over the input.

Some exercises such as `pascals-triangle` (`luhn` isn't the best example) can be substantially "solved" at compile-time in Nim. Since this is an interesting and accessible feature, we could consider adding a `topic` or `hint.md` to those exercises to indicate a bonus task.