### PR TITLE
Implement exercise: meetup

### DIFF
--- a/config.json
+++ b/config.json
@@ -503,6 +503,18 @@
       ]
     },
     {
+      "slug": "meetup",
+      "uuid": "adfbdcef-4d75-446f-9bfe-d3c7f28d8d2f",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "dates",
+        "enumerations",
+        "transforming"
+      ]
+    },
+    {
       "slug": "secret-handshake",
       "uuid": "09623b3d-05ee-4825-aae8-6434c9538366",
       "core": false,

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -1,0 +1,57 @@
+# Meetup
+
+Calculate the date of meetups.
+
+Typically meetups happen on the same day of the week.  In this exercise, you
+will take a description of a meetup date, and return the actual meetup date.
+
+Examples of general descriptions are:
+
+- The first Monday of January 2017
+- The third Tuesday of January 2017
+- The wednesteenth of January 2017
+- The last Thursday of January 2017
+
+The descriptors you are expected to parse are:
+first, second, third, fourth, fifth, last, monteenth, tuesteenth, wednesteenth,
+thursteenth, friteenth, saturteenth, sunteenth
+
+Note that "monteenth", "tuesteenth", etc are all made up words. There was a
+meetup whose members realized that there are exactly 7 numbered days in a month
+that end in '-teenth'. Therefore, one is guaranteed that each day of the week
+(Monday, Tuesday, ...) will have exactly one date that is named with '-teenth'
+in every month.
+
+Given examples of a meetup dates, each containing a month, day, year, and
+descriptor calculate the date of the actual meetup.  For example, if given
+"The first Monday of January 2017", the correct meetup date is 2017/1/2.
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r meetup_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/meetup` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month [https://twitter.com/copiousfreetime](https://twitter.com/copiousfreetime)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/meetup/example.nim
+++ b/exercises/meetup/example.nim
@@ -1,0 +1,14 @@
+import strformat, times
+
+type Schedule* = enum
+  Teenth, First, Second, Third, Fourth, Last
+const startDay: array[Schedule, int] = [13, 1, 8, 15, 22, 1]
+
+proc meetup*(y: int, m: int, sched: Schedule, d: Weekday): string =
+  var dt = parse(&"{y}-{m}-{startDay[sched]}-12", "yyyy-M-d-hh", utc())
+
+  if sched == Last:
+    dt = dt + 1.months - 7.days
+
+  dt = dt + ((d.ord - dt.weekday.ord + 7) mod 7).days
+  result = dt.format("yyyy-MM-dd")

--- a/exercises/meetup/meetup_test.nim
+++ b/exercises/meetup/meetup_test.nim
@@ -1,0 +1,290 @@
+import unittest, times
+import meetup
+
+# version 1.1.0
+
+suite "Meetup":
+  test "monteenth of May 2013":
+    check meetup(2013, 5, Teenth, dMon) == "2013-05-13"
+
+  test "monteenth of August 2013":
+    check meetup(2013, 8, Teenth, dMon) == "2013-08-19"
+
+  test "monteenth of September 2013":
+    check meetup(2013, 9, Teenth, dMon) == "2013-09-16"
+
+  test "tuesteenth of March 2013":
+    check meetup(2013, 3, Teenth, dTue) == "2013-03-19"
+
+  test "tuesteenth of April 2013":
+    check meetup(2013, 4, Teenth, dTue) == "2013-04-16"
+
+  test "tuesteenth of August 2013":
+    check meetup(2013, 8, Teenth, dTue) == "2013-08-13"
+
+  test "wednesteenth of January 2013":
+    check meetup(2013, 1, Teenth, dWed) == "2013-01-16"
+
+  test "wednesteenth of February 2013":
+    check meetup(2013, 2, Teenth, dWed) == "2013-02-13"
+
+  test "wednesteenth of June 2013":
+    check meetup(2013, 6, Teenth, dWed) == "2013-06-19"
+
+  test "thursteenth of May 2013":
+    check meetup(2013, 5, Teenth, dThu) == "2013-05-16"
+
+  test "thursteenth of June 2013":
+    check meetup(2013, 6, Teenth, dThu) == "2013-06-13"
+
+  test "thursteenth of September 2013":
+    check meetup(2013, 9, Teenth, dThu) == "2013-09-19"
+
+  test "friteenth of April 2013":
+    check meetup(2013, 4, Teenth, dFri) == "2013-04-19"
+
+  test "friteenth of August 2013":
+    check meetup(2013, 8, Teenth, dFri) == "2013-08-16"
+
+  test "friteenth of September 2013":
+    check meetup(2013, 9, Teenth, dFri) == "2013-09-13"
+
+  test "saturteenth of February 2013":
+    check meetup(2013, 2, Teenth, dSat) == "2013-02-16"
+
+  test "saturteenth of April 2013":
+    check meetup(2013, 4, Teenth, dSat) == "2013-04-13"
+
+  test "saturteenth of October 2013":
+    check meetup(2013, 10, Teenth, dSat) == "2013-10-19"
+
+  test "sunteenth of May 2013":
+    check meetup(2013, 5, Teenth, dSun) == "2013-05-19"
+
+  test "sunteenth of June 2013":
+    check meetup(2013, 6, Teenth, dSun) == "2013-06-16"
+
+  test "sunteenth of October 2013":
+    check meetup(2013, 10, Teenth, dSun) == "2013-10-13"
+
+  test "first Monday of March 2013":
+    check meetup(2013, 3, First, dMon) == "2013-03-04"
+
+  test "first Monday of April 2013":
+    check meetup(2013, 4, First, dMon) == "2013-04-01"
+
+  test "first Tuesday of May 2013":
+    check meetup(2013, 5, First, dTue) == "2013-05-07"
+
+  test "first Tuesday of June 2013":
+    check meetup(2013, 6, First, dTue) == "2013-06-04"
+
+  test "first Wednesday of July 2013":
+    check meetup(2013, 7, First, dWed) == "2013-07-03"
+
+  test "first Wednesday of August 2013":
+    check meetup(2013, 8, First, dWed) == "2013-08-07"
+
+  test "first Thursday of September 2013":
+    check meetup(2013, 9, First, dThu) == "2013-09-05"
+
+  test "first Thursday of October 2013":
+    check meetup(2013, 10, First, dThu) == "2013-10-03"
+
+  test "first Friday of November 2013":
+    check meetup(2013, 11, First, dFri) == "2013-11-01"
+
+  test "first Friday of December 2013":
+    check meetup(2013, 12, First, dFri) == "2013-12-06"
+
+  test "first Saturday of January 2013":
+    check meetup(2013, 1, First, dSat) == "2013-01-05"
+
+  test "first Saturday of February 2013":
+    check meetup(2013, 2, First, dSat) == "2013-02-02"
+
+  test "first Sunday of March 2013":
+    check meetup(2013, 3, First, dSun) == "2013-03-03"
+
+  test "first Sunday of April 2013":
+    check meetup(2013, 4, First, dSun) == "2013-04-07"
+
+  test "second Monday of March 2013":
+    check meetup(2013, 3, Second, dMon) == "2013-03-11"
+
+  test "second Monday of April 2013":
+    check meetup(2013, 4, Second, dMon) == "2013-04-08"
+
+  test "second Tuesday of May 2013":
+    check meetup(2013, 5, Second, dTue) == "2013-05-14"
+
+  test "second Tuesday of June 2013":
+    check meetup(2013, 6, Second, dTue) == "2013-06-11"
+
+  test "second Wednesday of July 2013":
+    check meetup(2013, 7, Second, dWed) == "2013-07-10"
+
+  test "second Wednesday of August 2013":
+    check meetup(2013, 8, Second, dWed) == "2013-08-14"
+
+  test "second Thursday of September 2013":
+    check meetup(2013, 9, Second, dThu) == "2013-09-12"
+
+  test "second Thursday of October 2013":
+    check meetup(2013, 10, Second, dThu) == "2013-10-10"
+
+  test "second Friday of November 2013":
+    check meetup(2013, 11, Second, dFri) == "2013-11-08"
+
+  test "second Friday of December 2013":
+    check meetup(2013, 12, Second, dFri) == "2013-12-13"
+
+  test "second Saturday of January 2013":
+    check meetup(2013, 1, Second, dSat) == "2013-01-12"
+
+  test "second Saturday of February 2013":
+    check meetup(2013, 2, Second, dSat) == "2013-02-09"
+
+  test "second Sunday of March 2013":
+    check meetup(2013, 3, Second, dSun) == "2013-03-10"
+
+  test "second Sunday of April 2013":
+    check meetup(2013, 4, Second, dSun) == "2013-04-14"
+
+  test "third Monday of March 2013":
+    check meetup(2013, 3, Third, dMon) == "2013-03-18"
+
+  test "third Monday of April 2013":
+    check meetup(2013, 4, Third, dMon) == "2013-04-15"
+
+  test "third Tuesday of May 2013":
+    check meetup(2013, 5, Third, dTue) == "2013-05-21"
+
+  test "third Tuesday of June 2013":
+    check meetup(2013, 6, Third, dTue) == "2013-06-18"
+
+  test "third Wednesday of July 2013":
+    check meetup(2013, 7, Third, dWed) == "2013-07-17"
+
+  test "third Wednesday of August 2013":
+    check meetup(2013, 8, Third, dWed) == "2013-08-21"
+
+  test "third Thursday of September 2013":
+    check meetup(2013, 9, Third, dThu) == "2013-09-19"
+
+  test "third Thursday of October 2013":
+    check meetup(2013, 10, Third, dThu) == "2013-10-17"
+
+  test "third Friday of November 2013":
+    check meetup(2013, 11, Third, dFri) == "2013-11-15"
+
+  test "third Friday of December 2013":
+    check meetup(2013, 12, Third, dFri) == "2013-12-20"
+
+  test "third Saturday of January 2013":
+    check meetup(2013, 1, Third, dSat) == "2013-01-19"
+
+  test "third Saturday of February 2013":
+    check meetup(2013, 2, Third, dSat) == "2013-02-16"
+
+  test "third Sunday of March 2013":
+    check meetup(2013, 3, Third, dSun) == "2013-03-17"
+
+  test "third Sunday of April 2013":
+    check meetup(2013, 4, Third, dSun) == "2013-04-21"
+
+  test "fourth Monday of March 2013":
+    check meetup(2013, 3, Fourth, dMon) == "2013-03-25"
+
+  test "fourth Monday of April 2013":
+    check meetup(2013, 4, Fourth, dMon) == "2013-04-22"
+
+  test "fourth Tuesday of May 2013":
+    check meetup(2013, 5, Fourth, dTue) == "2013-05-28"
+
+  test "fourth Tuesday of June 2013":
+    check meetup(2013, 6, Fourth, dTue) == "2013-06-25"
+
+  test "fourth Wednesday of July 2013":
+    check meetup(2013, 7, Fourth, dWed) == "2013-07-24"
+
+  test "fourth Wednesday of August 2013":
+    check meetup(2013, 8, Fourth, dWed) == "2013-08-28"
+
+  test "fourth Thursday of September 2013":
+    check meetup(2013, 9, Fourth, dThu) == "2013-09-26"
+
+  test "fourth Thursday of October 2013":
+    check meetup(2013, 10, Fourth, dThu) == "2013-10-24"
+
+  test "fourth Friday of November 2013":
+    check meetup(2013, 11, Fourth, dFri) == "2013-11-22"
+
+  test "fourth Friday of December 2013":
+    check meetup(2013, 12, Fourth, dFri) == "2013-12-27"
+
+  test "fourth Saturday of January 2013":
+    check meetup(2013, 1, Fourth, dSat) == "2013-01-26"
+
+  test "fourth Saturday of February 2013":
+    check meetup(2013, 2, Fourth, dSat) == "2013-02-23"
+
+  test "fourth Sunday of March 2013":
+    check meetup(2013, 3, Fourth, dSun) == "2013-03-24"
+
+  test "fourth Sunday of April 2013":
+    check meetup(2013, 4, Fourth, dSun) == "2013-04-28"
+
+  test "last Monday of March 2013":
+    check meetup(2013, 3, Last, dMon) == "2013-03-25"
+
+  test "last Monday of April 2013":
+    check meetup(2013, 4, Last, dMon) == "2013-04-29"
+
+  test "last Tuesday of May 2013":
+    check meetup(2013, 5, Last, dTue) == "2013-05-28"
+
+  test "last Tuesday of June 2013":
+    check meetup(2013, 6, Last, dTue) == "2013-06-25"
+
+  test "last Wednesday of July 2013":
+    check meetup(2013, 7, Last, dWed) == "2013-07-31"
+
+  test "last Wednesday of August 2013":
+    check meetup(2013, 8, Last, dWed) == "2013-08-28"
+
+  test "last Thursday of September 2013":
+    check meetup(2013, 9, Last, dThu) == "2013-09-26"
+
+  test "last Thursday of October 2013":
+    check meetup(2013, 10, Last, dThu) == "2013-10-31"
+
+  test "last Friday of November 2013":
+    check meetup(2013, 11, Last, dFri) == "2013-11-29"
+
+  test "last Friday of December 2013":
+    check meetup(2013, 12, Last, dFri) == "2013-12-27"
+
+  test "last Saturday of January 2013":
+    check meetup(2013, 1, Last, dSat) == "2013-01-26"
+
+  test "last Saturday of February 2013":
+    check meetup(2013, 2, Last, dSat) == "2013-02-23"
+
+  test "last Sunday of March 2013":
+    check meetup(2013, 3, Last, dSun) == "2013-03-31"
+
+  test "last Sunday of April 2013":
+    check meetup(2013, 4, Last, dSun) == "2013-04-28"
+
+  test "last Wednesday of February 2012":
+    check meetup(2012, 2, Last, dWed) == "2012-02-29"
+
+  test "last Wednesday of December 2014":
+    check meetup(2014, 12, Last, dWed) == "2014-12-31"
+
+  test "last Sunday of February 2015":
+    check meetup(2015, 2, Last, dSun) == "2015-02-22"
+
+  test "first Friday of December 2012":
+    check meetup(2012, 12, First, dFri) == "2012-12-07"


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/meetup/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/meetup/canonical-data.json)


### Comments
- The return type is a `string`, not `DateTime` or `int`.
- The weekday parameter is of type `Weekday`, not `string`.
- For good Nim style, the parameters should be ordered to best support method-call syntax. But I just use the upstream order of `2015.meetup(2, Last, dSun)` - I'm not convinced that something like `dSun.meetup(Last, 2015, 2)` is sufficiently improved.
- As a style convention, I use `func` when possible. In this exercise, `proc` is necessary because side-effects are introduced by `times`.
- This exercise shouldn't be the first to use `times`, or the first to use `enum`.
- There is an opportunity to practise using Nim's enum-indexed arrays.
- There are some open issues in the `problem-specifications` repo regarding suboptimal test descriptions and test grouping for `meetup`, but let's just follow the current upstream.


#### Return type
Here's how other tracks implement the return type:

| Type               | Language name                                                      |
| ------------------ | ------------------------------------------------------------------ |
| DateTime           | C#, F#, PHP, Perl 5                                                |
| Date               | Python, Java, JavaScript, Elixir, Ruby, Scala, Erlang, Kotlin, C++ |
| Int                | Go, Haskell (uses Modified Julian Day), Lua, C                     |
| String             | Swift, Delphi                                                      |
| Vector/Tuple/Array | Clojure, Ocaml, Lisp                                               |
| Not implemented    | Rust, TypeScript, Elm, Julia, R, Crystal, D, Dart, etc             |

`Date` is a natural return type for the languages that have `Date`, and the `DateTime` languages rely on the constructor returning a `DateTime` whose time component equals midnight. For example, F# tests for equality against the `DateTime(year, month, day)` overload.

But Nim has no `Date`, only a `DateTime`, and there is no equivalent `initDateTime(year, month, day)`. The `initDateTime` procs require `hour`, `minute` and `second` parameters, and provide no default values for them. Therefore I see the possibilities as:
1. `int`
```Nim
    check meetup(2015, 2, Last, dSun) == 22
```


2. `string`
```Nim
    check meetup(2015, 2, Last, dSun) == "2015-02-22"
```


3. `DateTime` (with `format`)
```Nim
    check meetup(2015, 2, Last, dSun).format("yyyy-MM-dd") == "2015-02-22"
```


4a. `DateTime` (with `parse`)
```Nim
    check meetup(2015, 2, Last, dSun) == "2015-02-22".parse("yyyy-MM-dd", utc())
```


4b. `DateTime` (with `initDateTime`)
```Nim
    check meetup(2015, 2, Last, dSun) == initDateTime(22, mFeb, 2015, 12, 00, 00, utc())
```


I think:
- 4a and 4b are poor choices, especially as they hardcode a certain timezone and time.
- 2 is better than 3 because there's less for a student to practise.
- 1 is the cleanest expression of the exercise, compared with `string` which has repetition of the year and month.

In particular, [the Go track's approach](https://github.com/exercism/go/blob/master/exercises/meetup/cases_test.go) seems elegant. They declare compliance with the latest version of the `canonical-data` and don't use a `hints.md` file.

However, I think `string` could be more suitable because:
- Formatting a `DateTime` is probably more common than getting a day of the month from a `DateTime`; it's better for the user to practise using `format` than `monthday`.
- The upstream-generated `README.md` wording doesn't encourage an `int` return type:

> Given examples of a meetup dates, each containing a month, day, year, and
> descriptor calculate the date of the actual meetup.  For example, if given
> "The first Monday of January 2017", the correct meetup date is 2017/1/2.