### PR TITLE
Implement exercise: pascals-triangle

### DIFF
--- a/config.json
+++ b/config.json
@@ -515,6 +515,17 @@
       ]
     },
     {
+      "slug": "pascals-triangle",
+      "uuid": "9ba153ad-bd49-4c26-9d80-dadb496cb637",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "algorithms",
+        "math"
+      ]
+    },
+    {
       "slug": "secret-handshake",
       "uuid": "09623b3d-05ee-4825-aae8-6434c9538366",
       "core": false,

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -1,0 +1,45 @@
+# Pascal's Triangle
+
+Compute Pascal's triangle up to a given number of rows.
+
+In Pascal's Triangle each number is computed by adding the numbers to
+the right and left of the current position in the previous row.
+
+```text
+    1
+   1 1
+  1 2 1
+ 1 3 3 1
+1 4 6 4 1
+# ... etc
+```
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r pascals_triangle_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/pascals-triangle` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Pascal's Triangle at Wolfram Math World [http://mathworld.wolfram.com/PascalsTriangle.html](http://mathworld.wolfram.com/PascalsTriangle.html)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pascals-triangle/example.nim
+++ b/exercises/pascals-triangle/example.nim
@@ -1,0 +1,15 @@
+func createTriangle(n: int): seq[seq[int]] =
+  result = @[@[1]]
+
+  for i in 1 .. n:
+    var row = newSeqOfCap[int](n)
+    row &= 1
+    for j in 1 ..< i:
+      row &= result[i-1][j-1] + result[i-1][j]
+    row &= 1
+    result &= row
+
+const p = createTriangle(30) # Generate rows of the triangle at compile-time.
+
+func pascal*(n: int): seq[seq[int]] =
+  p[0 ..< n]

--- a/exercises/pascals-triangle/pascals_triangle_test.nim
+++ b/exercises/pascals-triangle/pascals_triangle_test.nim
@@ -1,0 +1,67 @@
+import unittest
+import pascals_triangle
+
+# version 1.5.0
+
+suite "Pascal's Triangle":
+  test "zero rows":
+    check pascal(0).len == 0
+
+  test "single row":
+    check pascal(1) == @[
+      @[1]
+    ]
+
+  test "two rows":
+    check pascal(2) == @[
+      @[1],
+      @[1, 1]
+    ]
+
+  test "three rows":
+    check pascal(3) == @[
+      @[1],
+      @[1, 1],
+      @[1, 2, 1]
+    ]
+
+  test "four rows":
+    check pascal(4) == @[
+      @[1],
+      @[1, 1],
+      @[1, 2, 1],
+      @[1, 3, 3, 1]
+    ]
+
+  test "five rows":
+    check pascal(5) == @[
+      @[1],
+      @[1, 1],
+      @[1, 2, 1],
+      @[1, 3, 3, 1],
+      @[1, 4, 6, 4, 1]
+    ]
+
+  test "six rows":
+    check pascal(6) == @[
+      @[1],
+      @[1, 1],
+      @[1, 2, 1],
+      @[1, 3, 3, 1],
+      @[1, 4, 6, 4, 1],
+      @[1, 5, 10, 10, 5, 1]
+    ]
+
+  test "ten rows":
+    check pascal(10) == @[
+      @[1],
+      @[1, 1],
+      @[1, 2, 1],
+      @[1, 3, 3, 1],
+      @[1, 4, 6, 4, 1],
+      @[1, 5, 10, 10, 5, 1],
+      @[1, 6, 15, 20, 15, 6, 1],
+      @[1, 7, 21, 35, 35, 21, 7, 1],
+      @[1, 8, 28, 56, 70, 56, 28, 8, 1],
+      @[1, 9, 36, 84, 126, 126, 84, 36, 9, 1]
+    ]


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/pascals-triangle/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/pascals-triangle/canonical-data.json)


### Comments
This is a good exercise for compile-time computation. We could add a `hints.md` file to such exercises, or add a `topic` in `config.json` to suggest it as a bonus task.

In the example solution I generate 30 rows just so that the maximum integer produced won't overflow on 32-bit architectures.