### PR TITLE
Implement exercise: protein-translation

### DIFF
--- a/config.json
+++ b/config.json
@@ -550,6 +550,17 @@
       ]
     },
     {
+      "slug": "protein-translation",
+      "uuid": "2121a163-8dce-4267-b8de-d1952c1491e8",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "maps",
+        "strings"
+      ]
+    },
+    {
       "slug": "secret-handshake",
       "uuid": "09623b3d-05ee-4825-aae8-6434c9538366",
       "core": false,

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -1,0 +1,72 @@
+# Protein Translation
+
+Translate RNA sequences into proteins.
+
+RNA can be broken into three nucleotide sequences called codons, and then translated to a polypeptide like so:
+
+RNA: `"AUGUUUUCU"` => translates to
+
+Codons: `"AUG", "UUU", "UCU"`
+=> which become a polypeptide with the following sequence =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.  If it works for one codon, the program should work for all of them.
+However, feel free to expand the list in the test suite to include them all.
+
+There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
+
+All subsequent codons after are ignored, like this:
+
+RNA: `"AUGUUUUCUUAAAUG"` =>
+
+Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
+
+Below are the codons and resulting Amino Acids needed for the exercise.
+
+Codon                 | Protein
+:---                  | :---
+AUG                   | Methionine
+UUU, UUC              | Phenylalanine
+UUA, UUG              | Leucine
+UCU, UCC, UCA, UCG    | Serine
+UAU, UAC              | Tyrosine
+UGU, UGC              | Cysteine
+UGG                   | Tryptophan
+UAA, UAG, UGA         | STOP
+
+Learn more about [protein translation on Wikipedia](http://en.wikipedia.org/wiki/Translation_(biology))
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r protein_translation_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/protein-translation` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Tyler Long
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/protein-translation/example.nim
+++ b/exercises/protein-translation/example.nim
@@ -1,0 +1,37 @@
+import tables
+
+const codonToAminoAcid = {
+  "AUG": "Methionine",
+  "UUU": "Phenylalanine",
+  "UUC": "Phenylalanine",
+  "UUA": "Leucine",
+  "UUG": "Leucine",
+  "UCU": "Serine",
+  "UCC": "Serine",
+  "UCA": "Serine",
+  "UCG": "Serine",
+  "UAU": "Tyrosine",
+  "UAC": "Tyrosine",
+  "UGU": "Cysteine",
+  "UGC": "Cysteine",
+  "UGG": "Tryptophan",
+  "UAA": "STOP",
+  "UAG": "STOP",
+  "UGA": "STOP",
+}.toTable
+
+func translate*(s: string): seq[string] =
+  if s.len mod 3 != 0:
+    raise newException(ValueError, "Invalid RNA sequence: " & s)
+
+  for i in countup(0, s.high, 3):
+    let codon = s[i..i+2]
+
+    if codon notin codonToAminoAcid:
+      raise newException(ValueError, "Unknown codon: " & codon)
+
+    let aminoAcid = codonToAminoAcid[codon]
+    if aminoAcid == "STOP":
+      return
+    else:
+      result &= aminoAcid

--- a/exercises/protein-translation/protein_translation_test.nim
+++ b/exercises/protein-translation/protein_translation_test.nim
@@ -1,0 +1,64 @@
+import unittest
+import protein_translation
+
+# version 1.1.1
+
+suite "Protein Translation":
+  test "identifies Methionine codon":
+    check translate("AUG") == @["Methionine"]
+
+  test "identifies Phenylalanine codons":
+    for codon in ["UUU", "UUC"]:
+      check translate(codon) == @["Phenylalanine"]
+
+  test "identifies Leucine codons":
+    for codon in ["UUA", "UUG"]:
+      check translate(codon) == @["Leucine"]
+
+  test "identifies Serine codons":
+    for codon in ["UCU", "UCC", "UCA", "UCG"]:
+      check translate(codon) == @["Serine"]
+
+  test "identifies Tyrosine codons":
+    for codon in ["UAU", "UAC"]:
+      check translate(codon) == @["Tyrosine"]
+
+  test "identifies Cysteine codons":
+    for codon in ["UGU", "UGC"]:
+      check translate(codon) == @["Cysteine"]
+
+  test "identifies Tryptophan codon":
+    check translate("UGG") == @["Tryptophan"]
+
+  test "identifies STOP codons":
+    for codon in ["UAA", "UAG", "UGA"]:
+      check translate(codon).len == 0
+
+  test "translates RNA strand into correct protein":
+    const strand = "AUGUUUUGG"
+    const expected = @["Methionine", "Phenylalanine", "Tryptophan"]
+    check translate(strand) == expected
+
+  test "stops translation if STOP codon at beginning of sequence":
+    const strand = "UAGUGG"
+    check translate(strand).len == 0
+
+  test "stops translation if STOP codon at end of two-codon sequence":
+    const strand = "UGGUAG"
+    const expected = @["Tryptophan"]
+    check translate(strand) == expected
+
+  test "stops translation if STOP codon at end of three-codon sequence":
+    const strand = "AUGUUUUAA"
+    const expected = @["Methionine", "Phenylalanine"]
+    check translate(strand) == expected
+
+  test "stops translation if STOP codon in middle of three-codon sequence":
+    const strand = "UGGUAGUGG"
+    const expected = @["Tryptophan"]
+    check translate(strand) == expected
+
+  test "stops translation if STOP codon in middle of six-codon sequence":
+    const strand = "UGGUGUUAUUAAUGGUUU"
+    const expected = @["Tryptophan", "Cysteine", "Tyrosine"]
+    check translate(strand) == expected


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/protein-translation/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/protein-translation/canonical-data.json)


### Comments
The return type is `seq[string]`, not a `seq` of some amino acid `enum`. An `enum` implementation would cover the same ground as other `enum` exercises, and any such amino acid `enum` should contain all the canonical amino acids, rather than just the ones used for this exercise. I looked at some other tracks and didn't see one that used an `enum`.

The tests do not require the example solution's `raise` statements.