### PR TITLE
Implement exercise: resistor-color

### DIFF
--- a/config.json
+++ b/config.json
@@ -561,6 +561,17 @@
       ]
     },
     {
+      "slug": "resistor-color",
+      "uuid": "b239a0f3-47b5-4583-985f-c98efca8259e",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "arrays",
+        "enumerations"
+      ]
+    },
+    {
       "slug": "secret-handshake",
       "uuid": "09623b3d-05ee-4825-aae8-6434c9538366",
       "core": false,

--- a/exercises/resistor-color/README.md
+++ b/exercises/resistor-color/README.md
@@ -1,0 +1,50 @@
+# Resistor Color
+
+Resistors have color coded bands, where each color maps to a number. The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
+
+These colors are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array: Better Be Right Or Your Great Big Values Go Wrong.
+
+More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article](https://en.wikipedia.org/wiki/Electronic_color_code)
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r resistor_color_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/resistor-color` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Maud de Vries, Erik Schierboom [https://github.com/exercism/problem-specifications/issues/1458](https://github.com/exercism/problem-specifications/issues/1458)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/resistor-color/example.nim
+++ b/exercises/resistor-color/example.nim
@@ -1,0 +1,9 @@
+type ResistorColor* = enum
+  Black, Brown, Red, Orange, Yellow, Green, Blue, Violet, Grey, White
+
+func colorCode*(color: ResistorColor): int =
+  color.ord
+
+func colors*: array[0..ResistorColor.high.ord, ResistorColor] =
+  for c in ResistorColor:
+    result[c.ord] = c

--- a/exercises/resistor-color/resistor_color_test.nim
+++ b/exercises/resistor-color/resistor_color_test.nim
@@ -1,0 +1,18 @@
+import unittest
+import resistor_color
+
+# version 1.0.0
+
+suite "Resistor Color":
+  test "black":
+    check colorCode(Black) == 0
+
+  test "white":
+    check colorCode(White) == 9
+
+  test "orange":
+    check colorCode(Orange) == 3
+
+  test "all resistor colors":
+    check colors() == [Black, Brown, Red, Orange, Yellow,
+                       Green, Blue, Violet, Grey, White]


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/resistor-color/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/resistor-color/canonical-data.json)


### Comments
The return type of `colors` is `array`, not `seq`.

However, a `seq` implementation will also pass the tests as e.g. `@[1, 2] == [1, 2]` is `true`.