### PR TITLE
Implement exercise: say

### DIFF
--- a/config.json
+++ b/config.json
@@ -584,6 +584,19 @@
       ]
     },
     {
+      "slug": "say",
+      "uuid": "ef24428e-289c-48d0-967b-961d95246f3c",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "integers",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ]
+    },
+    {
       "slug": "secret-handshake",
       "uuid": "09623b3d-05ee-4825-aae8-6434c9538366",
       "core": false,

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -1,0 +1,93 @@
+# Say
+
+Given a number from 0 to 999,999,999,999, spell out that number in English.
+
+## Step 1
+
+Handle the basic case of 0 through 99.
+
+If the input to the program is `22`, then the output should be
+`'twenty-two'`.
+
+Your program should complain loudly if given a number outside the
+blessed range.
+
+Some good test cases for this program are:
+
+- 0
+- 14
+- 50
+- 98
+- -1
+- 100
+
+### Extension
+
+If you're on a Mac, shell out to Mac OS X's `say` program to talk out
+loud. If you're on Linux or Windows, eSpeakNG may be available with the command `espeak`.
+
+## Step 2
+
+Implement breaking a number up into chunks of thousands.
+
+So `1234567890` should yield a list like 1, 234, 567, and 890, while the
+far simpler `1000` should yield just 1 and 0.
+
+The program must also report any values that are out of range.
+
+## Step 3
+
+Now handle inserting the appropriate scale word between those chunks.
+
+So `1234567890` should yield `'1 billion 234 million 567 thousand 890'`
+
+The program must also report any values that are out of range.  It's
+fine to stop at "trillion".
+
+## Step 4
+
+Put it all together to get nothing but plain English.
+
+`12345` should give `twelve thousand three hundred forty-five`.
+
+The program must also report any values that are out of range.
+
+### Extensions
+
+Use _and_ (correctly) when spelling out the number in English:
+
+- 14 becomes "fourteen".
+- 100 becomes "one hundred".
+- 120 becomes "one hundred and twenty".
+- 1002 becomes "one thousand and two".
+- 1323 becomes "one thousand three hundred and twenty-three".
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r say_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/say` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+A variation on JavaRanch CattleDrive, exercise 4a [http://www.javaranch.com/say.jsp](http://www.javaranch.com/say.jsp)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/say/example.nim
+++ b/exercises/say/example.nim
@@ -1,0 +1,33 @@
+const
+  small = ["zero", "one", "two", "three", "four", "five",
+           "six", "seven", "eight", "nine", "ten", "eleven",
+           "twelve", "thirteen", "fourteen", "fifteen",
+           "sixteen", "seventeen", "eighteen", "nineteen"]
+  tens = ["", "", "twenty", "thirty", "forty", "fifty",
+          "sixty", "seventy", "eighty", "ninety"]
+  scale = ["thousand", "million", "billion"]
+
+func say*(n: int64): string
+
+func leftover(sep: string, n: int64): string =
+  if n == 0:
+    ""
+  else:
+    sep & say(n)
+
+func say*(n: int64): string =
+  if n < 0 or n >= 1e12.int:
+    raise newException(ValueError, "Number is out of range: " & $n)
+
+  elif n < 20:
+    return small[n]
+
+  elif n < 100:
+    return tens[n div 10] & leftover("-", n mod 10)
+
+  elif n < 1000:
+    return small[n div 100] & " hundred" & leftover(" ", n mod 100)
+
+  for i, x in [1e3.int, 1e6.int, 1e9.int]:
+    if n < x * 1000:
+      return say(n div x) & " " & scale[i] & leftover(" ", n mod x)

--- a/exercises/say/say_test.nim
+++ b/exercises/say/say_test.nim
@@ -1,0 +1,55 @@
+import unittest
+import say
+
+# version 1.2.0
+
+suite "Say":
+  test "zero":
+    check say(0) == "zero"
+
+  test "one":
+    check say(1) == "one"
+
+  test "fourteen":
+    check say(14) == "fourteen"
+
+  test "twenty":
+    check say(20) == "twenty"
+
+  test "twenty-two":
+    check say(22) == "twenty-two"
+
+  test "one hundred":
+    check say(100) == "one hundred"
+
+  test "one hundred twenty-three":
+    check say(123) == "one hundred twenty-three"
+
+  test "one thousand":
+    check say(1000) == "one thousand"
+
+  test "one thousand two hundred thirty-four":
+    check say(1234) == "one thousand two hundred thirty-four"
+
+  test "one million":
+    check say(1_000_000) == "one million"
+
+  test "one million two thousand three hundred forty-five":
+    check say(1_002_345) == "one million two thousand three hundred forty-five"
+
+  test "one billion":
+    check say(1_000_000_000) == "one billion"
+
+  test "a big number":
+    check say(987_654_321_123) == "nine hundred eighty-seven billion " &
+                                  "six hundred fifty-four million " &
+                                  "three hundred twenty-one thousand " &
+                                  "one hundred twenty-three"
+
+  test "numbers below zero are out of range":
+    expect ValueError:
+      discard say(-1)
+
+  test "numbers above 999,999,999,999 are out of range":
+    expect ValueError:
+      discard say(1_000_000_000_000)


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/say/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/say/canonical-data.json)


### Comments
The example solution uses a forward declaration for `say`.

`int64` is used.

Some tracks extend this exercise by spelling out the number with "and".