### PR TITLE
Implement exercise: spiral-matrix

### DIFF
--- a/config.json
+++ b/config.json
@@ -638,6 +638,17 @@
       ]
     },
     {
+      "slug": "spiral-matrix",
+      "uuid": "32c1262c-4f60-45cf-a5eb-aae7ea19acfc",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "integers",
+        "matrices"
+      ]
+    },
+    {
       "slug": "binary",
       "uuid": "3acf148d-df9e-4897-8c9f-c17a3ba5e4b6",
       "core": false,

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -1,0 +1,54 @@
+# Spiral Matrix
+
+Given the size, return a square matrix of numbers in spiral order.
+
+The matrix should be filled with natural numbers, starting from 1
+in the top-left corner, increasing in an inward, clockwise spiral order,
+like these examples:
+
+###### Spiral matrix of size 3
+
+```text
+1 2 3
+8 9 4
+7 6 5
+```
+
+###### Spiral matrix of size 4
+
+```text
+ 1  2  3 4
+12 13 14 5
+11 16 15 6
+10  9  8 7
+```
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r spiral_matrix_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/spiral-matrix` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension. [https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/](https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/spiral-matrix/example.nim
+++ b/exercises/spiral-matrix/example.nim
@@ -1,0 +1,23 @@
+type Point = tuple[x, y: int]
+
+func `+=`(a: var Point, b: Point) =
+  a = (a.x + b.x, a.y + b.y)
+
+# Define x to increase rightwards, and y to increase downwards.
+const directions: array[4, Point] = [(1, 0), (0, 1), (-1, 0), (0, -1)]
+
+func spiral*(n: static int): array[n, array[n, int]] =
+  var walkLen = n
+  var count = 1
+  var p: Point = (-1, 0)  # Start outside the top left corner.
+
+  while walkLen > 0:
+    for d in directions:  # Walk in the order: right, down, left, up.
+      for _ in 1..walkLen:
+        p += d
+        result[p.y][p.x] = count
+        inc count
+
+      # Subtract 1 from the walk length after finishing a horizontal walk.
+      if d.y == 0:
+        dec walkLen

--- a/exercises/spiral-matrix/spiral_matrix_test.nim
+++ b/exercises/spiral-matrix/spiral_matrix_test.nim
@@ -1,0 +1,33 @@
+import unittest
+import spiral_matrix
+
+# version 1.1.0
+
+suite "Spiral Matrix":
+  test "empty spiral":
+    check spiral(0) == []
+
+  test "trivial spiral":
+    check spiral(1) == [[1]]
+
+  test "spiral of size 2":
+    check spiral(2) == [[1, 2],
+                        [4, 3]]
+
+  test "spiral of size 3":
+    check spiral(3) == [[1, 2, 3],
+                        [8, 9, 4],
+                        [7, 6, 5]]
+
+  test "spiral of size 4":
+    check spiral(4) == [[ 1,  2,  3, 4],
+                        [12, 13, 14, 5],
+                        [11, 16, 15, 6],
+                        [10,  9,  8, 7]]
+
+  test "spiral of size 5":
+    check spiral(5) == [[ 1,  2,  3,  4, 5],
+                        [16, 17, 18, 19, 6],
+                        [15, 24, 25, 20, 7],
+                        [14, 23, 22, 21, 8],
+                        [13, 12, 11, 10, 9]]


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/spiral-matrix/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/spiral-matrix/canonical-data.json)


### Comments
The matrix is always square, so a return type of `array[n, array[n, int]]` makes sense. It also reduces overlap with other nested `seq` exercises and gives users some practice with `static[T]`.

A `seq[array[n, int]]` implementation will also pass the tests, but `seq[seq[int]]` won't.

This exercise should be placed after exercises `matrix` and `saddle-points`.

We can consider adding a `hints.md` file to the first exercise on the track that uses `static[T]`.