### PR TITLE
Implement exercise: sublist

### DIFF
--- a/config.json
+++ b/config.json
@@ -649,6 +649,18 @@
       ]
     },
     {
+      "slug": "sublist",
+      "uuid": "08719e83-36ac-4f9a-9075-6edca3648d5d",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "enumerations",
+        "searching",
+        "sequences"
+      ]
+    },
+    {
       "slug": "binary",
       "uuid": "3acf148d-df9e-4897-8c9f-c17a3ba5e4b6",
       "core": false,

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -1,0 +1,44 @@
+# Sublist
+
+Given two lists determine if the first list is contained within the second
+list, if the second list is contained within the first list, if both lists are
+contained within each other or if none of these are true.
+
+Specifically, a list A is a sublist of list B if by dropping 0 or more elements
+from the front of B and 0 or more elements from the back of B you get a list
+that's completely equal to A.
+
+Examples:
+
+ * A = [1, 2, 3], B = [1, 2, 3, 4, 5], A is a sublist of B
+ * A = [3, 4, 5], B = [1, 2, 3, 4, 5], A is a sublist of B
+ * A = [3, 4], B = [1, 2, 3, 4, 5], A is a sublist of B
+ * A = [1, 2, 3], B = [1, 2, 3], A is equal to B
+ * A = [1, 2, 3, 4, 5], B = [2, 3, 4], A is a superlist of B
+ * A = [1, 2, 4], B = [1, 2, 3, 4, 5], A is not a superlist of, sublist of or equal to B
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r sublist_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/sublist` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sublist/example.nim
+++ b/exercises/sublist/example.nim
@@ -1,0 +1,29 @@
+type Comparison* = enum
+  Unequal, Sublist, Superlist, Equal
+
+func contains(a, b: openArray[int]): bool =
+  if len(b) == 0:
+    return true
+  elif len(b) > len(a):
+    return false
+
+  for i in 0 .. (a.high - b.high):
+    var foundDifference = false
+    if a[i] != b[0]:
+      continue
+    for j in 0 .. b.high:
+      if a[i + j] != b[j]:
+        foundDifference = true
+        break
+    if not foundDifference:
+      return true
+
+func sublist*(a, b: openArray[int]): Comparison =
+  if a == b:
+    Equal
+  elif a.contains(b):
+    Superlist
+  elif b.contains(a):
+    Sublist
+  else:
+    Unequal

--- a/exercises/sublist/sublist_test.nim
+++ b/exercises/sublist/sublist_test.nim
@@ -1,0 +1,56 @@
+import unittest
+import sublist
+
+# version 1.1.0
+
+suite "Sublist":
+  test "empty lists":
+    check sublist([], []) == Equal
+
+  test "empty list within non empty list":
+    check sublist([], [1, 2, 3]) == Sublist
+
+  test "non empty list contains empty list":
+    check sublist([1, 2, 3], []) == Superlist
+
+  test "list equals itself":
+    check sublist([1, 2, 3], [1, 2, 3]) == Equal
+
+  test "different lists":
+    check sublist([1, 2, 3], [2, 3, 4]) == Unequal
+
+  test "false start":
+    check sublist([1, 2, 5], [0, 1, 2, 3, 1, 2, 5, 6]) == Sublist
+
+  test "consecutive":
+    check sublist([1, 1, 2], [0, 1, 1, 1, 2, 1, 2]) == Sublist
+
+  test "sublist at start":
+    check sublist([0, 1, 2], [0, 1, 2, 3, 4, 5]) == Sublist
+
+  test "sublist in middle":
+    check sublist([2, 3, 4], [0, 1, 2, 3, 4, 5]) == Sublist
+
+  test "sublist at end":
+    check sublist([3, 4, 5], [0, 1, 2, 3, 4, 5]) == Sublist
+
+  test "at start of superlist":
+    check sublist([0, 1, 2, 3, 4, 5], [0, 1, 2]) == Superlist
+
+  test "in middle of superlist":
+    check sublist([0, 1, 2, 3, 4, 5], [2, 3]) == Superlist
+
+  test "at end of superlist":
+    check sublist([0, 1, 2, 3, 4, 5], [3, 4, 5]) == Superlist
+
+  test "first list missing element from second list":
+    check sublist([1, 3], [1, 2, 3]) == Unequal
+
+  test "second list missing element from first list":
+    check sublist([1, 2, 3], [1, 3]) == Unequal
+
+  test "order matters to a list":
+    check sublist([1, 2, 3], [3, 2, 1]) == Unequal
+
+  test "same digits but different numbers":
+    check sublist([1, 0, 1], [10, 1]) == Unequal


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/sublist/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/sublist/canonical-data.json)


### Comments
The input types are implemented as `array`, not `seq`. This pushes the user to use `openArray`, which is the correct type for functions that work with both `array` and `seq`. I think this is an important detail that this exercise can reinforce, rather than relying on mentors to suggest changes to every `sublist(a, b: seq[int])` implementation. Maybe we can pick an earlier exercise where that happens.

Nim defines `[1, 2] == @[1, 2]` as `true`, so it makes sense insist that `[1, 2].sublist(@[1, 2])` is possible (and returns `Equal`). Using `array` does this without adding extra tests, or altering the existing ones arbitrarily to compare combinations of `array` and `seq`.

That said, it could be useful to add an extra test with an `array` input to some exercise that uses `seq` otherwise (for example, `high-scores`). But I think we shouldn't always try to cater to `seq` solutions.

The `sublist` exercise should not be placed near the beginning of the track.

We can consider adding a `hints.md` file to the first exercise that requires `openArray`.