### PR TITLE
leap: Update tests to 1.5.0

### DIFF
--- a/exercises/leap/leap_test.nim
+++ b/exercises/leap/leap_test.nim
@@ -1,11 +1,14 @@
 import unittest
 import leap
 
-# version 1.4.0
+# version 1.5.0
 
 suite "Leap":
   test "year not divisible by 4: common year":
     check isLeapYear(2015) == false
+
+  test "year divisible by 2, not divisible by 4: common year":
+    check isLeapYear(1970) == false
 
   test "year divisible by 4, not divisible by 100: leap year":
     check isLeapYear(1996) == true


### PR DESCRIPTION
Updates `leap` to version 1.5.0, https://github.com/exercism/problem-specifications/pull/1465