### PR TITLE
Implement exercise: crypto-square

### DIFF
--- a/config.json
+++ b/config.json
@@ -421,6 +421,19 @@
       ]
     },
     {
+      "slug": "crypto-square",
+      "uuid": "a6e88c81-4f8b-45bb-8656-74f5a9554a12",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "cryptography",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ]
+    },
+    {
       "slug": "darts",
       "uuid": "c83824af-bac6-4e59-9bf0-df5ab3f83a3d",
       "core": false,

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -1,0 +1,103 @@
+# Crypto Square
+
+Implement the classic method for composing secret messages called a square code.
+
+Given an English text, output the encoded version of that text.
+
+First, the input is normalized: the spaces and punctuation are removed
+from the English text and the message is downcased.
+
+Then, the normalized characters are broken into rows.  These rows can be
+regarded as forming a rectangle when printed with intervening newlines.
+
+For example, the sentence
+
+```text
+"If man was meant to stay on the ground, god would have given us roots."
+```
+
+is normalized to:
+
+```text
+"ifmanwasmeanttostayonthegroundgodwouldhavegivenusroots"
+```
+
+The plaintext should be organized in to a rectangle.  The size of the
+rectangle (`r x c`) should be decided by the length of the message,
+such that `c >= r` and `c - r <= 1`, where `c` is the number of columns
+and `r` is the number of rows.
+
+Our normalized text is 54 characters long, dictating a rectangle with
+`c = 8` and `r = 7`:
+
+```text
+"ifmanwas"
+"meanttos"
+"tayonthe"
+"groundgo"
+"dwouldha"
+"vegivenu"
+"sroots  "
+```
+
+The coded message is obtained by reading down the columns going left to
+right.
+
+The message above is coded as:
+
+```text
+"imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau"
+```
+
+Output the encoded text in chunks that fill perfect rectangles `(r X c)`,
+with `c` chunks of `r` length, separated by spaces. For phrases that are
+`n` characters short of the perfect rectangle, pad each of the last `n`
+chunks with a single trailing space.
+
+```text
+"imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
+```
+
+Notice that were we to stack these, we could visually decode the
+ciphertext back in to the original message:
+
+```text
+"imtgdvs"
+"fearwer"
+"mayoogo"
+"anouuio"
+"ntnnlvt"
+"wttddes"
+"aohghn "
+"sseoau "
+```
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r crypto_square_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/crypto-square` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/crypto-square/crypto_square_test.nim
+++ b/exercises/crypto-square/crypto_square_test.nim
@@ -1,0 +1,28 @@
+import unittest
+import crypto_square
+
+# version 3.2.0
+
+suite "Crypto Square":
+  test "empty plaintext results in an empty ciphertext":
+    check encrypt("") == ""
+
+  test "lowercase":
+    check encrypt("A") == "a"
+
+  test "remove spaces":
+    check encrypt("  b ") == "b"
+
+  test "remove punctuation":
+    check encrypt("@1,%!") == "1"
+
+  test "9 character plaintext results in 3 chunks of 3 characters":
+    check encrypt("This is fun!") == "tsf hiu isn"
+
+  test "8 character plaintext results in 3 chunks, the last one with a trailing space":
+    check encrypt("Chill out.") == "clu hlt io "
+
+  test "54 character plaintext results in 7 chunks, the last two with trailing spaces":
+    const pt = "If man was meant to stay on the ground, god would have given us roots."
+    const expected = "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
+    check encrypt(pt) == expected

--- a/exercises/crypto-square/example.nim
+++ b/exercises/crypto-square/example.nim
@@ -1,0 +1,21 @@
+import math, strutils
+
+func encrypt*(s: string): string =
+  var normalized = newStringOfCap(s.len)
+  for c in s.toLowerAscii():
+    if c in {'a'..'z'} or c in {'0'..'9'}:
+      normalized &= c
+
+  let r = normalized.len.float.sqrt.ceil.int
+  let c = (normalized.len.float / r.float).round.int
+  normalized = normalized.alignLeft(r*c, ' ')
+
+  var ct = newSeq[string]()
+  for s in 0 ..< r:
+    var word = ""
+    for i in countup(s, normalized.high, r):
+      word &= normalized[i]
+
+    ct &= word
+
+  result = ct.join(" ")


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/crypto-square/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/crypto-square/canonical-data.json)


### Comments
Here's how various popular tracks name the function:

| Language | Function name     |
| -------- | ----------------- |
| F#       | `ciphertext`      |
| C#       | `ciphertext`      |
| Python   | `encode`          |
| Go       | `encode`          |
| Java     | `getCipherText`   |
| Haskell  | `encode`          |
| Elixir   | `encode`          |
| Ruby     | `ciphertext`      |
| Rust     | `encrypt`         |

I lean towards `encrypt`. It doesn't distinguish this function from the ones in other cryptography exercises, but neither do the other function names.

The `canonical-data` test names are relatively long.