### PR TITLE
Implement exercise: diamond

### DIFF
--- a/config.json
+++ b/config.json
@@ -446,6 +446,17 @@
       ]
     },
     {
+      "slug": "diamond",
+      "uuid": "675520e4-b763-4bdb-8d6a-740b12834fcb",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
       "slug": "etl",
       "uuid": "da9807c2-959d-49e0-86a9-44de02501f37",
       "core": false,

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -1,0 +1,83 @@
+# Diamond
+
+The diamond kata takes as its input a letter, and outputs it in a diamond
+shape. Given a letter, it prints a diamond starting with 'A', with the
+supplied letter at the widest point.
+
+## Requirements
+
+* The first row contains one 'A'.
+* The last row contains one 'A'.
+* All rows, except the first and last, have exactly two identical letters.
+* All rows have as many trailing spaces as leading spaces. (This might be 0).
+* The diamond is horizontally symmetric.
+* The diamond is vertically symmetric.
+* The diamond has a square shape (width equals height).
+* The letters form a diamond shape.
+* The top half has the letters in ascending order.
+* The bottom half has the letters in descending order.
+* The four corners (containing the spaces) are triangles.
+
+## Examples
+
+In the following examples, spaces are indicated by `·` characters.
+
+Diamond for letter 'A':
+
+```text
+A
+```
+
+Diamond for letter 'C':
+
+```text
+··A··
+·B·B·
+C···C
+·B·B·
+··A··
+```
+
+Diamond for letter 'E':
+
+```text
+····A····
+···B·B···
+··C···C··
+·D·····D·
+E·······E
+·D·····D·
+··C···C··
+···B·B···
+····A····
+```
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r diamond_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/diamond` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Seb Rose [http://claysnow.co.uk/recycling-tests-in-tdd/](http://claysnow.co.uk/recycling-tests-in-tdd/)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/diamond/diamond_test.nim
+++ b/exercises/diamond/diamond_test.nim
@@ -1,0 +1,87 @@
+import unittest
+import diamond
+
+# version 1.1.0
+
+suite "Diamond":
+  test "degenerate case with a single \"A\" row":
+    const expected = "A\n"
+    check diamond('A') == expected
+
+  test "degenerate case with no row containing 3 distinct groups of spaces":
+    const expected = " A \n" &
+                     "B B\n" &
+                     " A \n"
+    check diamond('B') == expected
+
+  test "smallest non-degenerate case with odd diamond side length":
+    const expected = "  A  \n" &
+                     " B B \n" &
+                     "C   C\n" &
+                     " B B \n" &
+                     "  A  \n"
+    check diamond('C') == expected
+
+  test "smallest non-degenerate case with even diamond side length":
+    const expected = "   A   \n" &
+                     "  B B  \n" &
+                     " C   C \n" &
+                     "D     D\n" &
+                     " C   C \n" &
+                     "  B B  \n" &
+                     "   A   \n"
+    check diamond('D') == expected
+
+  test "largest possible diamond":
+    const expected = "                         A                         \n" &
+                     "                        B B                        \n" &
+                     "                       C   C                       \n" &
+                     "                      D     D                      \n" &
+                     "                     E       E                     \n" &
+                     "                    F         F                    \n" &
+                     "                   G           G                   \n" &
+                     "                  H             H                  \n" &
+                     "                 I               I                 \n" &
+                     "                J                 J                \n" &
+                     "               K                   K               \n" &
+                     "              L                     L              \n" &
+                     "             M                       M             \n" &
+                     "            N                         N            \n" &
+                     "           O                           O           \n" &
+                     "          P                             P          \n" &
+                     "         Q                               Q         \n" &
+                     "        R                                 R        \n" &
+                     "       S                                   S       \n" &
+                     "      T                                     T      \n" &
+                     "     U                                       U     \n" &
+                     "    V                                         V    \n" &
+                     "   W                                           W   \n" &
+                     "  X                                             X  \n" &
+                     " Y                                               Y \n" &
+                     "Z                                                 Z\n" &
+                     " Y                                               Y \n" &
+                     "  X                                             X  \n" &
+                     "   W                                           W   \n" &
+                     "    V                                         V    \n" &
+                     "     U                                       U     \n" &
+                     "      T                                     T      \n" &
+                     "       S                                   S       \n" &
+                     "        R                                 R        \n" &
+                     "         Q                               Q         \n" &
+                     "          P                             P          \n" &
+                     "           O                           O           \n" &
+                     "            N                         N            \n" &
+                     "             M                       M             \n" &
+                     "              L                     L              \n" &
+                     "               K                   K               \n" &
+                     "                J                 J                \n" &
+                     "                 I               I                 \n" &
+                     "                  H             H                  \n" &
+                     "                   G           G                   \n" &
+                     "                    F         F                    \n" &
+                     "                     E       E                     \n" &
+                     "                      D     D                      \n" &
+                     "                       C   C                       \n" &
+                     "                        B B                        \n" &
+                     "                         A                         \n"
+    check diamond('Z') == expected

--- a/exercises/diamond/example.nim
+++ b/exercises/diamond/example.nim
@@ -1,0 +1,23 @@
+import strutils
+
+func toDiamond(c: char): seq[string] =
+  let rowLen = 2 * (c.ord - 'A'.ord) + 1
+  let emptyRow = " ".repeat(rowLen)
+
+  for ch in 'A' .. c:
+    var row = emptyRow
+    let i = c.ord - ch.ord
+    row[i] = ch
+    row[^(i + 1)] = ch
+    result &= row
+  for i in countdown(result.high - 1, 0):
+    result &= result[i]
+
+func generateDiamonds: seq[string] =
+  for c in 'A'..'Z':
+    result &= c.toDiamond.join("\n") & "\n"
+
+const diamonds = generateDiamonds() # Generate all diamonds at compile-time.
+
+func diamond*(c: char): string =
+  diamonds[c.ord - 'A'.ord]


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/diamond/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/diamond/canonical-data.json)


### Comments
This is another exercise where a lookup can be computed at compile-time.

Some tracks (e.g. C#, F#, Go) do not use the `canonical-data` for this exercise and instead use their own property-based tests.


#### Return type of `string` or `seq[string]`?
The upstream exercise description arguably implies that the return type is `string`. Nevertheless, some prominent tracks do use a `seq[string]`-like data structure, which means that the user doesn't have to think about newlines in a final `string` representation.

I think that `seq[string]` is more elegant, but it reduces the range of possible solutions.

Here's how various tracks implement the return type:

| Language                                                                                                     | `string`? |
| ------------------------------------------------------------------------------------------------------------ | --------- |
| [C#](https://github.com/exercism/csharp/blob/master/exercises/diamond/DiamondTest.cs)                        | ✔️         |
| [Elixir](https://github.com/exercism/elixir/blob/master/exercises/diamond/diamond_test.exs)                  | ✔️         |
| [F#](https://github.com/exercism/fsharp/blob/master/exercises/diamond/DiamondTest.fs)                        | ✔️         |
| [Go](https://github.com/exercism/go/blob/master/exercises/diamond/diamond_test.go)                           | ✔️         |
| [Haskell](https://github.com/exercism/haskell/blob/master/exercises/diamond/test/Tests.hs)                   |           |
| [Java](https://github.com/exercism/java/blob/master/exercises/diamond/src/test/java/DiamondPrinterTest.java) |           |
| [Javascript](https://github.com/exercism/javascript/blob/master/exercises/diamond/diamond.spec.js)           | ✔️         |
| [Python](https://github.com/exercism/python/blob/master/exercises/diamond/diamond_test.py)                   | ✔️         |
| [Ruby](https://github.com/exercism/ruby/blob/master/exercises/diamond/diamond_test.rb)                       | ✔️         |
| [Rust](https://github.com/exercism/rust/blob/master/exercises/diamond/tests/diamond.rs)                      |           |
| [Scala](https://github.com/exercism/scala/blob/master/exercises/diamond/src/test/scala/DiamondTest.scala)    |           |

I lean towards `string` here, but I don't think there's a clear winner.

There would be a similar question for the upcoming `proverb` and `twelve-days`, but their exercise descriptions more strongly imply `string`.


#### Use `join` in tests?
In the tests, `expected` can be defined using `.join("\n") & "\n"` like

```Nim
const expected = @[" A ",
                   "B B",
                   " A "].join("\n") & "\n"
```

or explicitly like

```Nim
const expected = " A \n" &
                 "B B\n" &
                 " A \n"
```

I lean towards the latter here because:
- `.join` might unduly bias users to use it in their implementation, at the expense of other valid approaches (such as constructing the string in one pass)
- it makes the `const expected = "A\n"` test consistent with the others
- the `.join("\n") & "\n"` for the last diamond makes that line too long - it would be placed underneath
- the return type is perhaps more immediately obvious
- it doesn't need an extra import


The Ruby and Elixir tracks have an `expected` that looks like my implementation. Again, I don't think there's a clear winner.
