### PR TITLE
Implement exercise: diffie-hellman

### DIFF
--- a/config.json
+++ b/config.json
@@ -457,6 +457,20 @@
       ]
     },
     {
+      "slug": "diffie-hellman",
+      "uuid": "bf9a2fc3-def5-4bfc-a944-91bb213ad8b5",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "algorithms",
+        "cryptography",
+        "integers",
+        "math",
+        "randomness"
+      ]
+    },
+    {
       "slug": "etl",
       "uuid": "da9807c2-959d-49e0-86a9-44de02501f37",
       "core": false,

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -1,0 +1,68 @@
+# Diffie Hellman
+
+Diffie-Hellman key exchange.
+
+Alice and Bob use Diffie-Hellman key exchange to share secrets.  They
+start with prime numbers, pick private keys, generate and share public
+keys, and then generate a shared secret key.
+
+## Step 0
+
+The test program supplies prime numbers p and g.
+
+## Step 1
+
+Alice picks a private key, a, greater than 1 and less than p.  Bob does
+the same to pick a private key b.
+
+## Step 2
+
+Alice calculates a public key A.
+
+    A = g**a mod p
+
+Using the same p and g, Bob similarly calculates a public key B from his
+private key b.
+
+## Step 3
+
+Alice and Bob exchange public keys.  Alice calculates secret key s.
+
+    s = B**a mod p
+
+Bob calculates
+
+    s = A**b mod p
+
+The calculations produce the same result!  Alice and Bob now share
+secret s.
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r diffie_hellman_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/diffie-hellman` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Wikipedia, 1024 bit key from www.cryptopp.com/wiki. [http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange](http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/diffie-hellman/diffie_hellman_test.nim
+++ b/exercises/diffie-hellman/diffie_hellman_test.nim
@@ -1,0 +1,46 @@
+import unittest, intsets
+import diffie_hellman
+
+# version 1.0.0
+
+suite "Diffie Hellman":
+  test "private key is greater than 1 and less than p":
+    const primes = [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]
+    for p in primes:
+      let a = privateKey(p)
+      check a > 1 and a < p
+
+  test "private key is random":
+    # A correct implementation has a tiny chance of failing this test.
+    let p = int.high
+    var privateKeys = initIntSet()
+    const n = 100
+    for i in 1..n:
+      privateKeys.incl(privateKey(p))
+    check privateKeys.len == n
+
+  test "can calculate public key using private key":
+    const p = 23
+    const g = 5
+    const privateKey = 6
+    check publicKey(p, g, privateKey) == 8
+
+  test "can calculate secret using other party's public key":
+    const p = 23
+    const theirPublicKey = 19
+    const myPrivateKey = 6
+    check secret(p, theirPublicKey, myPrivateKey) == 2
+
+  test "key exchange":
+    # Nim does not support big integers in the standard library.
+    # To demonstrate key exchange, p is a small prime for this test.
+    # It must be a large prime for security in the real world.
+    const p = 7
+    const g = 3
+    let alicePrivateKey = privateKey(p)
+    let bobPrivateKey = privateKey(p)
+    let alicePublicKey = publicKey(p, g, alicePrivateKey)
+    let bobPublicKey = publicKey(p, g, bobPrivateKey)
+    let secretA = secret(p, bobPublicKey, alicePrivateKey)
+    let secretB = secret(p, alicePublicKey, bobPrivateKey)
+    check secretA == secretB

--- a/exercises/diffie-hellman/example.nim
+++ b/exercises/diffie-hellman/example.nim
@@ -1,0 +1,26 @@
+import random
+
+randomize()
+
+func powMod(b: Natural, e: Natural, m: Positive): int =
+  ## Returns the value of `b` raised to the power `e`, modulo `m`.
+  ## Running time is O(log e). It is O(e) for the naive `b^e mod m`.
+  ## This will overflow if m > int.high.float.sqrt
+  result = 1
+  var b = b mod m
+  var e = e
+
+  while e > 0:
+    if (e and 1) == 1:
+      result = (result * b) mod m
+    e = e shr 1
+    b = (b * b) mod m
+
+proc privateKey*(p: int): int =
+  rand(2 ..< p)
+
+func publicKey*(p, g, a: int): int =
+  powMod(g, a, p)
+
+func secret*(p, bPub, a: int): int =
+  powMod(bPub, a, p)


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/diffie-hellman/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/diffie-hellman/canonical-data.json)


### Comments
#### Big integers
Most tracks that implement this exercise either have built-in bigints, or are using a bigint library. Nim does not have bigints in the stdlib, and I don't think we should start using Nimble packages yet.

Unless I'm missing something, the lack of bigints presents an issue with the final `canonical-data` test. The [`p = 23`](https://github.com/exercism/problem-specifications/blob/51418ec78bcca075b586d4c38d66d2c322b488fe/exercises/diffie-hellman/canonical-data.json#L60) produces an overflow about 30% of the time when:
- The integer type stores a maximum value of `2^63 - 1`
- Modular exponentiation is implemented in the direct way (`B^a mod p`)

The overflow happens because:
- The final test uses `p = 23`, `g = 5`
- The `privateKey` function produces key `a` in the range `1 < a < p` (here `2..22`)
- The `publicKey` functions with naive implementation `g^a mod p` will not overflow on 64-bit architectures, as `5^22 < int.high`.
- However, the `secret` naive implementation performs `B^a mod p`, where `B` and `a` can both have values of up to 22. Therefore it is common to require computation of e.g. `8^22` or `16^16`, which is greater than`int.high`.

I see two solutions:
- Insist that users implement modular exponentiation such that the final test doesn't cause overflows
- Change `p` and `g` to smaller values in the final test

I think the latter is better. It's not glamorous, but I choose `p = 7` and `g = 3` so that it doesn't overflow even on 32-bit systems.

I'll get round to reporting an issue upstream after I double-check myself because it conflicts with the `canonical-data` saying "Although the calculations fundamentally do not require large numbers".

In `example.nim` I implement a less naive version of modular exponentiation. The Rust track does something similar.


#### Test for randomness
The `canonical-data` contains
```json
{
    "description": "private key is random",
    "property": "privateKeyIsRandom",
    "input": {},
    "expected": {
    "random": true
    }
},
```

This doesn't specify an approach for testing randomness, but it is clearly out-of-scope for this test to fully verify the randomness of the RNG. There is some variation in what other tracks do. For example:
- [Elixir](https://github.com/exercism/elixir/blob/b5457ed9f704becc4ec953382f1d4d14daded39f/exercises/diffie-hellman/diffie_hellman_test.exs#L27)
- [Python](https://github.com/exercism/python/blob/222c02976c2c0e75d03440893f543c760ca39ba9/exercises/diffie-hellman/diffie_hellman_test.py#L15)
- [Go](https://github.com/exercism/go/blob/88f9630e868f5c1ad5c5393b7158aa8a3b89bb53/exercises/diffie-hellman/diffie_hellman_test.go#L81)

These simply check the generated keys "uniqueness", not their "randomness". It would be possible to check that the distribution of keys looks random, but it probably isn't very useful, so I implement something similar. But note that a `privateKey` function that simply counts upwards will pass this test.

I don't write the probability that the test fails - the other tracks don't seem to do it. But it is extremely low.

#### Misc
- The exercise title is apparently `Diffie Hellman` not `Diffie-Hellman`. The `suite` name matches that.
- A single uppercase letter is not a recommended Nim identifier; I name `B` as `bPub` in the `example.nim`.