### PR TITLE
Implement exercise: phone-number

### DIFF
--- a/config.json
+++ b/config.json
@@ -589,6 +589,18 @@
       ]
     },
     {
+      "slug": "phone-number",
+      "uuid": "7cb027d9-6841-443a-9168-fb1347abe891",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "conditionals",
+        "parsing",
+        "strings"
+      ]
+    },
+    {
       "slug": "prime-factors",
       "uuid": "869c033a-052c-4031-9402-970824bb520a",
       "core": false,

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -1,0 +1,59 @@
+# Phone Number
+
+Clean up user-entered phone numbers so that they can be sent SMS messages.
+
+The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code: `1`.
+
+NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
+
+The format is usually represented as
+
+```text
+(NXX)-NXX-XXXX
+```
+
+where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9.
+
+Your task is to clean up differently formatted telephone numbers by removing punctuation and the country code (1) if present.
+
+For example, the inputs
+- `+1 (613)-995-0253`
+- `613-995-0253`
+- `1 613 995 0253`
+- `613.995.0253`
+
+should all produce the output
+
+`6139950253`
+
+**Note:** As this exercise only deals with telephone numbers used in NANP-countries, only 1 is considered a valid country code.
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r phone_number_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/phone-number` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Event Manager by JumpstartLab [http://tutorials.jumpstartlab.com/projects/eventmanager.html](http://tutorials.jumpstartlab.com/projects/eventmanager.html)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/phone-number/example.nim
+++ b/exercises/phone-number/example.nim
@@ -1,0 +1,10 @@
+func clean*(s: string): string =
+  for c in s:
+    if c in {'0'..'9'}:
+      result &= c
+
+  if result.len == 11 and result[0] == '1':
+    result = result[1 .. ^1]
+
+  if result.len != 10 or result[0] in {'0', '1'} or result[3] in {'0', '1'}:
+    raise newException(ValueError, "Invalid phone number: " & s)

--- a/exercises/phone-number/phone_number_test.nim
+++ b/exercises/phone-number/phone_number_test.nim
@@ -1,0 +1,72 @@
+import unittest
+import phone_number
+
+# version 1.7.0
+
+suite "Phone Number":
+  test "cleans the number":
+    check clean("(223) 456-7890") == "2234567890"
+
+  test "cleans numbers with dots":
+    check clean("223.456.7890") == "2234567890"
+
+  test "cleans numbers with multiple spaces":
+    check clean("223 456   7890   ") == "2234567890"
+
+  test "invalid when 9 digits":
+    expect ValueError:
+      discard clean("123456789")
+
+  test "invalid when 11 digits does not start with a 1":
+    expect ValueError:
+      discard clean("22234567890")
+
+  test "valid when 11 digits and starting with 1":
+    check clean("12234567890") == "2234567890"
+
+  test "valid when 11 digits and starting with 1 even with punctuation":
+    check clean("+1 (223) 456-7890") == "2234567890"
+
+  test "invalid when more than 11 digits":
+    expect ValueError:
+      discard clean("321234567890")
+
+  test "invalid with letters":
+    expect ValueError:
+      discard clean("123-abc-7890")
+
+  test "invalid with punctuations":
+    expect ValueError:
+      discard clean("123-@:!-7890")
+
+  test "invalid if area code starts with 0":
+    expect ValueError:
+      discard clean("(023) 456-7890")
+
+  test "invalid if area code starts with 1":
+    expect ValueError:
+      discard clean("(123) 456-7890")
+
+  test "invalid if exchange code starts with 0":
+    expect ValueError:
+      discard clean("(223) 056-7890")
+
+  test "invalid if exchange code starts with 1":
+    expect ValueError:
+      discard clean("(223) 156-7890")
+
+  test "invalid if area code starts with 0 on valid 11-digit number":
+    expect ValueError:
+      discard clean("1 (023) 456-7890")
+
+  test "invalid if area code starts with 1 on valid 11-digit number":
+    expect ValueError:
+      discard clean("1 (123) 456-7890")
+
+  test "invalid if exchange code starts with 0 on valid 11-digit number":
+    expect ValueError:
+      discard clean("1 (223) 056-7890")
+
+  test "invalid if exchange code starts with 1 on valid 11-digit number":
+    expect ValueError:
+      discard clean("1 (223) 156-7890")


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/phone-number/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/phone-number/canonical-data.json)


### Comments
This exercise is another candidate if we ever want to give users some practice with the [options](https://nim-lang.github.io/Nim/options.html) module. Some tracks (e.g. [Rust](https://github.com/exercism/rust/blob/master/exercises/phone-number/tests/phone-number.rs)) do something similar.

An informal benchmark shows that removing the first character of `result` in-place with 

```Nim
for i in 0 .. 9:
  result[i] = result[i+1]
result.setLen(10)
```

makes `clean` run about 10% faster than using

```Nim
result = result[1 .. ^1]
```