### PR TITLE
Implement exercise: proverb

### DIFF
--- a/config.json
+++ b/config.json
@@ -623,6 +623,17 @@
       ]
     },
     {
+      "slug": "proverb",
+      "uuid": "8d876470-08d5-4efe-b9d1-4a6812c1e586",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "loops",
+        "strings"
+      ]
+    },
+    {
       "slug": "resistor-color",
       "uuid": "b239a0f3-47b5-4583-985f-c98efca8259e",
       "core": false,

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -1,0 +1,47 @@
+# Proverb
+
+For want of a horseshoe nail, a kingdom was lost, or so the saying goes.
+
+Given a list of inputs, generate the relevant proverb. For example, given the list `["nail", "shoe", "horse", "rider", "message", "battle", "kingdom"]`, you will output the full text of this proverbial rhyme:
+
+```text
+For want of a nail the shoe was lost.
+For want of a shoe the horse was lost.
+For want of a horse the rider was lost.
+For want of a rider the message was lost.
+For want of a message the battle was lost.
+For want of a battle the kingdom was lost.
+And all for the want of a nail.
+```
+
+Note that the list of inputs may vary; your solution should be able to handle lists of arbitrary length and content. No line of the output text should be a static, unchanging string; all should vary according to the input given.
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r proverb_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/proverb` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/For_Want_of_a_Nail](http://en.wikipedia.org/wiki/For_Want_of_a_Nail)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/proverb/example.nim
+++ b/exercises/proverb/example.nim
@@ -1,0 +1,10 @@
+import strformat
+
+func recite*(s: openArray[string]): string =
+  if s.len == 0:
+    return
+
+  for i in 0 .. s.high - 1:
+    result &= &"For want of a {s[i]} the {s[i+1]} was lost.\n"
+
+  result &= &"And all for the want of a {s[0]}."

--- a/exercises/proverb/proverb_test.nim
+++ b/exercises/proverb/proverb_test.nim
@@ -1,0 +1,48 @@
+import unittest
+import proverb
+
+# version 1.1.0
+
+suite "Proverb":
+  test "zero pieces":
+    const words: seq[string] = @[]
+    const expected = ""
+    check recite(words) == expected
+
+  test "one piece":
+    const words = @["nail"]
+    const expected = "And all for the want of a nail."
+    check recite(words) == expected
+
+  test "two pieces":
+    const words = @["nail", "shoe"]
+    const expected = "For want of a nail the shoe was lost.\n" &
+                     "And all for the want of a nail."
+    check recite(words) == expected
+
+  test "three pieces":
+    const words = @["nail", "shoe", "horse"]
+    const expected = "For want of a nail the shoe was lost.\n" &
+                     "For want of a shoe the horse was lost.\n" &
+                     "And all for the want of a nail."
+    check recite(words) == expected
+
+  test "full proverb":
+    const words = @["nail", "shoe", "horse", "rider",
+                    "message", "battle", "kingdom"]
+    const expected = "For want of a nail the shoe was lost.\n" &
+                     "For want of a shoe the horse was lost.\n" &
+                     "For want of a horse the rider was lost.\n" &
+                     "For want of a rider the message was lost.\n" &
+                     "For want of a message the battle was lost.\n" &
+                     "For want of a battle the kingdom was lost.\n" &
+                     "And all for the want of a nail."
+    check recite(words) == expected
+
+  test "four pieces modernized":
+    const words = @["pin", "gun", "soldier", "battle"]
+    const expected = "For want of a pin the gun was lost.\n" &
+                     "For want of a gun the soldier was lost.\n" &
+                     "For want of a soldier the battle was lost.\n" &
+                     "And all for the want of a pin."
+    check recite(words) == expected


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/proverb/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/proverb/canonical-data.json)


### Comments
The return type is implemented as `string`, not `seq[string]`. This is arguably less elegant (as the user must handle newlines), but it might fit the exercise description better.