### PR TITLE
Implement exercise: resistor-color-duo

### DIFF
--- a/config.json
+++ b/config.json
@@ -645,6 +645,18 @@
       ]
     },
     {
+      "slug": "resistor-color-duo",
+      "uuid": "85c8f6d3-5802-4894-9929-5aa62d7a4840",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "arrays",
+        "enumerations",
+        "transforming"
+      ]
+    },
+    {
       "slug": "rotational-cipher",
       "uuid": "b60b8bfd-a2a7-4da0-8a22-894fff5abab2",
       "core": false,

--- a/exercises/resistor-color-duo/README.md
+++ b/exercises/resistor-color-duo/README.md
@@ -1,0 +1,52 @@
+# Resistor Color Duo
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_. For this exercise, you need to know two things about them:
+
+* Each resistor has a resistance value.
+* Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+
+In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take two colors as input, and output the correct number.
+
+The band colors are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r resistor_color_duo_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/resistor-color-duo` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Maud de Vries, Erik Schierboom [https://github.com/exercism/problem-specifications/issues/1464](https://github.com/exercism/problem-specifications/issues/1464)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/resistor-color-duo/example.nim
+++ b/exercises/resistor-color-duo/example.nim
@@ -1,0 +1,5 @@
+type ResistorColor* = enum
+  Black, Brown, Red, Orange, Yellow, Green, Blue, Violet, Grey, White
+
+func value*(colors: array[2, ResistorColor]): int =
+  10 * colors[0].ord + colors[1].ord

--- a/exercises/resistor-color-duo/resistor_color_duo_test.nim
+++ b/exercises/resistor-color-duo/resistor_color_duo_test.nim
@@ -1,0 +1,17 @@
+import unittest
+import resistor_color_duo
+
+# version 2.0.0
+
+suite "Resistor Color Duo":
+  test "brown and black":
+    check value([Brown, Black]) == 10
+
+  test "blue and grey":
+    check value([Blue, Grey]) == 68
+
+  test "yellow and violet":
+    check value([Yellow, Violet]) == 47
+
+  test "orange and orange":
+    check value([Orange, Orange]) == 33


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/resistor-color-duo/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/resistor-color-duo/canonical-data.json)


### Comments
I implement the input type as `array`, not `seq`. This is because:
- The `value` function is only defined for a container of length 2.
- It seems more important to allow a parameter of type `array[2, ResistorColor]` rather than allowing `seq[ResistorColor]` (a `seq` parameter should almost always be an `openArray` instead). Of course, both allow `openArray[ResistorColor]`.
- It allows the user to practise defining arrays, which is rare on the Nim track and a goal of the resistor exercises.
- Input validation tests were deliberately not included upstream (see https://github.com/exercism/problem-specifications/pull/1466), and such tests would arguably be desirable for a `seq` version.
 
Overall I think it's better to encourage using a fixed length data structure for functions that are only defined for a fixed length input. This finds bugs at compile-time, and doesn't suggest input validation tests.