### PR TITLE
Implement exercise: robot-name

### DIFF
--- a/config.json
+++ b/config.json
@@ -657,6 +657,17 @@
       ]
     },
     {
+      "slug": "robot-name",
+      "uuid": "5d2fa542-245a-4c5b-bfe1-bd667091c556",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "randomness",
+        "strings"
+      ]
+    },
+    {
       "slug": "rotational-cipher",
       "uuid": "b60b8bfd-a2a7-4da0-8a22-894fff5abab2",
       "core": false,

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -1,0 +1,46 @@
+# Robot Name
+
+Manage robot factory settings.
+
+When robots come off the factory floor, they have no name.
+
+The first time you boot them up, a random name is generated in the format
+of two uppercase letters followed by three digits, such as RX837 or BC811.
+
+Every once in a while we need to reset a robot to its factory settings,
+which means that their name gets wiped. The next time you ask, it will
+respond with a new random name.
+
+The names must be random: they should not follow a predictable sequence.
+Random names means a risk of collisions. Your solution must ensure that
+every existing robot has a unique name.
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r robot_name_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/robot-name` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+A debugging session with Paul Blackwell at gSchool. [http://gschool.it](http://gschool.it)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/robot-name/example.nim
+++ b/exercises/robot-name/example.nim
@@ -1,0 +1,33 @@
+import intsets, random, strutils
+
+type Robot = tuple[name: string]
+const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const numNames = 26 * 26 * 10 * 10 * 10
+var nums = initIntSet()
+nums.incl(numNames)
+randomize()
+
+func createLeadingZerosLookup: array[1000, string] =
+  for i in 0 .. result.high:
+    result[i] = i.`$`.align(3, '0')
+
+const zeroPad = createLeadingZerosLookup()
+
+func toName(n: Natural): string =
+  let b = n div 1000
+  let a = b div 26
+  result = alphabet[a mod 26] & alphabet[b mod 26] & zeroPad[n mod 1000]
+
+proc getUnusedName(s: var IntSet): string =
+  var i = numNames
+  # The below is faster than shuffling when generating a small number of names.
+  while i in s:
+    i = rand(numNames)
+  s.incl(i)
+  result = toName(i)
+
+proc makeRobot*: Robot =
+  result.name = getUnusedName(nums)
+
+proc reset*(r: var Robot) =
+  r.name = getUnusedName(nums)

--- a/exercises/robot-name/robot_name_test.nim
+++ b/exercises/robot-name/robot_name_test.nim
@@ -1,0 +1,46 @@
+import unittest, sets
+import robot_name
+
+func isValidRobotName(s: string): bool =
+  ## Returns true if `s` is two uppercase letters followed by three digits.
+  s.len == 5 and
+    s[0] in {'A'..'Z'} and
+    s[1] in {'A'..'Z'} and
+    s[2] in {'0'..'9'} and
+    s[3] in {'0'..'9'} and
+    s[4] in {'0'..'9'}
+
+suite "Robot Name":
+  test "robot has a valid name":
+    var robot = makeRobot()
+    check isValidRobotName(robot.name)
+
+  test "name is persistent":
+    var robot = makeRobot()
+    let name1 = robot.name
+    let name2 = robot.name
+    check name1 == name2
+
+  test "different robots have different names":
+    let name1 = makeRobot().name
+    let name2 = makeRobot().name
+    check name1 != name2
+
+  test "reset changes name":
+    var robot = makeRobot()
+    let nameBefore = robot.name
+    robot.reset()
+    let nameAfter = robot.name
+    check:
+      nameBefore != nameAfter
+      isValidRobotName(nameAfter)
+
+  # Bonus
+  # This test is optional. Uncomment the lines below to enable it.
+
+  # test "all remaining robot names are distinct":
+  #   const n = (26 * 26 * 1000) - 6 # The number of names not generated above.
+  #   var names = initSet[string](n.rightSize)
+  #   for i in 1 .. n:
+  #     names.incl(makeRobot().name)
+  #   check names.len == n


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/robot-name/description.md)
(No canonical data)

### Comments
This is the first exercise on the Nim track that doesn't have canonical data. The are considerable differences in how other tracks implement it.

#### Bonus test for name uniqueness
The exercise description states
> Your solution must ensure that every existing robot has a unique name.

But out of 28 tracks that implement `robot-name`, only half test for uniqueness. Of these, six test all possible names - they are `go`, `javascript`, `ocaml`, `perl6`, `ruby` and `scala`.

| Track                                                                                    | Tests many names?                                                                                                  | How many?       |
| ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------------- |
| [clojure](https://www.github.com/exercism/clojure/tree/master/exercises/robot-name)         | [no](https://github.com/exercism/clojure/blob/master/exercises/robot-name/test/robot_name_test.clj)                |                 |
| [common-lisp](https://www.github.com/exercism/common-lisp/tree/master/exercises/robot-name) | [no](https://github.com/exercism/common-lisp/blob/master/exercises/robot-name/robot-name-test.lisp)                |                 |
| [cpp](https://www.github.com/exercism/cpp/tree/master/exercises/robot-name)                 | [yes](https://github.com/exercism/cpp/blob/master/exercises/robot-name/robot_name_test.cpp)                        | 1,000           |
| [csharp](https://www.github.com/exercism/csharp/tree/master/exercises/robot-name)           | [yes](https://github.com/exercism/csharp/blob/master/exercises/robot-name/RobotNameTest.cs)                        | 10,000          |
| [d](https://www.github.com/exercism/d/tree/master/exercises/robot-name)                     | [yes](https://github.com/exercism/d/blob/master/exercises/robot-name/source/robot_name.d)                          | 10,000          |
| [delphi](https://www.github.com/exercism/delphi/tree/master/exercises/robot-name)           | [yes](https://github.com/exercism/delphi/blob/master/exercises/robot-name/uRobotNameTest.pas)                      | 20,000          |
| [elisp](https://www.github.com/exercism/elisp/tree/master/exercises/robot-name)             | [no](https://github.com/exercism/elisp/blob/master/exercises/robot-name/robot-name-test.el)                        |                 |
| [fsharp](https://www.github.com/exercism/fsharp/tree/master/exercises/robot-name)           | [no](https://github.com/exercism/fsharp/blob/master/exercises/robot-name/RobotNameTest.fs)                         |                 |
| [go](https://www.github.com/exercism/go/tree/master/exercises/robot-name)                   | [yes](https://github.com/exercism/go/blob/master/exercises/robot-name/bonus_test.go)                               | all             |
| [groovy](https://www.github.com/exercism/groovy/tree/master/exercises/robot-name)           | [no](https://github.com/exercism/groovy/blob/master/exercises/robot-name/src/test/groovy/RobotNameSpec.groovy)     |                 |
| [haskell](https://www.github.com/exercism/haskell/tree/master/exercises/robot-name)         | [yes](https://github.com/exercism/haskell/blob/master/exercises/robot-name/test/Tests.hs)                          | 5,000           |
| [java](https://www.github.com/exercism/java/tree/master/exercises/robot-name)               | [no](https://github.com/exercism/java/blob/master/exercises/robot-name/src/test/java/RobotTest.java)               |                 |
| [javascript](https://www.github.com/exercism/javascript/tree/master/exercises/robot-name)   | [yes](https://github.com/exercism/javascript/blob/master/exercises/robot-name/robot-name.spec.js)                  | all             |
| [julia](https://www.github.com/exercism/julia/tree/master/exercises/robot-name)             | [no](https://github.com/exercism/julia/blob/master/exercises/robot-name/runtests.jl)                               |                 |
| [kotlin](https://www.github.com/exercism/kotlin/tree/master/exercises/robot-name)           | [yes](https://github.com/exercism/kotlin/blob/master/exercises/robot-name/src/test/kotlin/RobotTest.kt)            | 100,000         |
| [lua](https://www.github.com/exercism/lua/tree/master/exercises/robot-name)                 | [no](https://github.com/exercism/lua/blob/master/exercises/robot-name/robot-name_spec.lua)                         |                 |
| [objective-c](https://www.github.com/exercism/objective-c/tree/master/exercises/robot-name) | [no](https://github.com/exercism/objective-c/blob/master/exercises/robot-name/RobotNameTest.m)                     |                 |
| [ocaml](https://www.github.com/exercism/ocaml/tree/master/exercises/robot-name)             | [yes](https://github.com/exercism/ocaml/blob/master/exercises/robot-name/test.ml)                                  | all             |
| [perl5](https://www.github.com/exercism/perl5/tree/master/exercises/robot-name)             | [no](https://github.com/exercism/perl5/blob/master/exercises/robot-name/robot_name.t)                              |                 |
| [perl6](https://www.github.com/exercism/perl6/tree/master/exercises/robot-name)             | [yes](https://github.com/exercism/perl6/blob/master/exercises/robot-name/robot-name.t)                             | all             |
| [php](https://www.github.com/exercism/php/tree/master/exercises/robot-name)                 | [yes](https://github.com/exercism/php/blob/master/exercises/robot-name/robot-name_test.php)                        | 10,000          |
| [python](https://www.github.com/exercism/python/tree/master/exercises/robot-name)           | [no](https://github.com/exercism/python/blob/master/exercises/robot-name/robot_name_test.py)                       |                 |
| [ruby](https://www.github.com/exercism/ruby/tree/master/exercises/robot-name)               | [yes](https://github.com/exercism/ruby/blob/master/exercises/robot-name/robot_name_test.rb)                        | all             |
| [rust](https://www.github.com/exercism/rust/tree/master/exercises/robot-name)               | [no](https://github.com/exercism/rust/blob/master/exercises/robot-name/tests/robot-name.rs)                        |                 |
| [scala](https://www.github.com/exercism/scala/tree/master/exercises/robot-name)             | [yes](https://github.com/exercism/scala/blob/master/exercises/robot-name/src/test/scala/RobotNameTest.scala)       | all             |
| [scheme](https://www.github.com/exercism/scheme/tree/master/exercises/robot-name)           | [no](https://github.com/exercism/scheme/blob/master/exercises/robot-name/robot-name-test.scm)                      |                 |
| [swift](https://www.github.com/exercism/swift/tree/master/exercises/robot-name)             | [no](https://github.com/exercism/swift/blob/master/exercises/robot-name/Tests/RobotNameTests/RobotNameTests.swift) |                 |
| [typescript](https://www.github.com/exercism/typescript/tree/master/exercises/robot-name)   | [yes](https://github.com/exercism/typescript/blob/master/exercises/robot-name/robot-name.test.ts)                  | 10,000          |

The exercise is easier without a test for uniqueness. One implementation that would pass is:

```Nim
import random, strutils

type Robot = tuple[name: string]
randomize()

proc getName: string =
  rand('A'..'Z') & rand('A'..'Z') & rand(999).`$`.align(3, '0')

proc makeRobot*: Robot =
  result.name = getName()

proc reset*(r: var Robot) =
  r.name = getName()
```

I feel that generating distinct names is the most interesting part of the exercise, so I think it's worth the bonus test. Generating only a few thousand names is sufficient to test a good implementation, but we might as well test all the names - it catches some bad implementations and adds an uncommon performance aspect.

However, the full test is by far the most computationally intense test on the Nim track, so I think it should be uncommented manually by the user (Nim's `unittest` module does have `skip` functionality, but it still executes the "skipped" test code). A good implementation should still run all the tests within a couple of seconds (in debug mode) even on a slow machine.

The example implementation is optimized for the tests that run on CI - generating a small number of names. For a large fraction of names, it is faster to generate all the names and shuffle them (possibly at compile-time), but this has a noticeable overhead when the bonus test is commented out.

The bonus test is implemented similarly to that of `scala` - I think it adds a lot of noise to `incl` the names from the non-bonus tests.


#### Other tests
Here are some other tests that exist on at least one track:

| Test                                                    | Track                      |
| ------------------------------------------------------- | -------------------------- |
| Names aren't sequential                                 | `javascript`, `typescript` |
| An error is raised when names are exhausted             | `go`, `perl6`              |
| Resetting a robot affects only one robot                | `haskell`                  |
| All names are generated within a certain amount of time | `ruby`                     |
| Names are distinct after resets                         | various                    |

I don't think any of these are necessary for now.