### PR TITLE
Implement exercise: scale-generator

### DIFF
--- a/config.json
+++ b/config.json
@@ -705,6 +705,17 @@
       ]
     },
     {
+      "slug": "scale-generator",
+      "uuid": "b81e2ff7-5d11-499d-acc5-0448d1b1af47",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "pattern_matching",
+        "strings"
+      ]
+    },
+    {
       "slug": "secret-handshake",
       "uuid": "09623b3d-05ee-4825-aae8-6434c9538366",
       "core": false,

--- a/exercises/scale-generator/README.md
+++ b/exercises/scale-generator/README.md
@@ -1,0 +1,75 @@
+# Scale Generator
+
+Given a tonic, or starting note, and a set of intervals, generate
+the musical scale starting with the tonic and following the
+specified interval pattern.
+
+Scales in Western music are based on the chromatic (12-note) scale. This
+scale can be expressed as the following group of pitches:
+
+A, A#, B, C, C#, D, D#, E, F, F#, G, G#
+
+A given sharp note (indicated by a #) can also be expressed as the flat
+of the note above it (indicated by a b) so the chromatic scale can also be
+written like this:
+
+A, Bb, B, C, Db, D, Eb, E, F, Gb, G, Ab
+
+The major and minor scale and modes are subsets of this twelve-pitch
+collection. They have seven pitches, and are called diatonic scales.
+The collection of notes in these scales is written with either sharps or
+flats, depending on the tonic. Here is a list of which are which:
+
+No Sharps or Flats:
+C major
+a minor
+
+Use Sharps:
+G, D, A, E, B, F# major
+e, b, f#, c#, g#, d# minor
+
+Use Flats:
+F, Bb, Eb, Ab, Db, Gb major
+d, g, c, f, bb, eb minor
+
+The diatonic scales, and all other scales that derive from the
+chromatic scale, are built upon intervals. An interval is the space
+between two pitches.
+
+The simplest interval is between two adjacent notes, and is called a
+"half step", or "minor second" (sometimes written as a lower-case "m").
+The interval between two notes that have an interceding note is called
+a "whole step" or "major second" (written as an upper-case "M"). The
+diatonic scales are built using only these two intervals between
+adjacent notes.
+
+Non-diatonic scales can contain other intervals.  An "augmented first"
+interval, written "A", has two interceding notes (e.g., from A to C or
+Db to E). There are also smaller and larger intervals, but they will not
+figure into this exercise.
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r scale_generator_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/scale-generator` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/scale-generator/example.nim
+++ b/exercises/scale-generator/example.nim
@@ -1,0 +1,16 @@
+import sets, strutils, tables
+
+const
+  chromaticSharps = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+  chromaticFlats = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"]
+  flatKeys = ["F", "Bb", "Eb", "Ab", "Db", "Gb", "d", "g", "c", "f", "bb", "eb"].toSet
+  semitones = {'m': 1, 'M': 2, 'A': 3}.toTable
+  defaultIntervals = "m".repeat(12)
+
+func scale*(tonic: string, intervals = defaultIntervals): seq[string] =
+  let chromatic = if tonic in flatKeys: chromaticFlats else: chromaticSharps
+  var i = chromatic.find(tonic.capitalizeAscii)
+
+  for c in intervals:
+    result &= chromatic[i mod 12]
+    i += semitones[c]

--- a/exercises/scale-generator/scale_generator_test.nim
+++ b/exercises/scale-generator/scale_generator_test.nim
@@ -1,0 +1,58 @@
+import unittest
+import scale_generator
+
+# version 2.0.0
+
+suite "Scale Generator":
+  test "chromatic scale with sharps":
+    check scale("C") == @["C", "C#", "D", "D#", "E", "F",
+                          "F#", "G", "G#", "A", "A#", "B"]
+
+  test "chromatic scale with flats":
+    check scale("F") == @["F", "Gb", "G", "Ab", "A", "Bb",
+                          "B", "C", "Db", "D", "Eb", "E"]
+
+  test "simple major scale":
+    check scale("C", "MMmMMMm") == @["C", "D", "E", "F", "G", "A", "B"]
+
+  test "major scale with sharps":
+    check scale("G", "MMmMMMm") == @["G", "A", "B", "C", "D", "E", "F#"]
+
+  test "major scale with flats":
+    check scale("F", "MMmMMMm") == @["F", "G", "A", "Bb", "C", "D", "E"]
+
+  test "minor scale with sharps":
+    check scale("f#", "MmMMmMM") == @["F#", "G#", "A", "B", "C#", "D", "E"]
+
+  test "minor scale with flats":
+    check scale("bb", "MmMMmMM") == @["Bb", "C", "Db", "Eb", "F", "Gb", "Ab"]
+
+  test "dorian mode":
+    check scale("d", "MmMMMmM") == @["D", "E", "F", "G", "A", "B", "C"]
+
+  test "mixolydian mode":
+    check scale("Eb", "MMmMMmM") == @["Eb", "F", "G", "Ab", "Bb", "C", "Db"]
+
+  test "lydian mode":
+    check scale("a", "MMMmMMm") == @["A", "B", "C#", "D#", "E", "F#", "G#"]
+
+  test "phrygian mode":
+    check scale("e", "mMMMmMM") == @["E", "F", "G", "A", "B", "C", "D"]
+
+  test "locrian mode":
+    check scale("g", "mMMmMMM") == @["G", "Ab", "Bb", "C", "Db", "Eb", "F"]
+
+  test "harmonic minor":
+    check scale("d", "MmMMmAm") == @["D", "E", "F", "G", "A", "Bb", "Db"]
+
+  test "octatonic":
+    check scale("C", "MmMmMmMm") == @["C", "D", "D#", "F", "F#", "G#", "A", "B"]
+
+  test "hexatonic":
+    check scale("Db", "MMMMMM") == @["Db", "Eb", "F", "G", "A", "B"]
+
+  test "pentatonic":
+    check scale("A", "MMAMA") == @["A", "B", "C#", "E", "F#"]
+
+  test "enigmatic":
+    check scale("G", "mAMMMmm") == @["G", "G#", "B", "C#", "D#", "F", "F#"]


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/scale-generator/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/scale-generator/canonical-data.json)


### Comments
I implement the intervals input type as `string`. One alternative could be `seq[Interval]`, where `Interval` is

```Nim
type Interval = enum
  m, M, A
```

The example implementation could be faster by avoiding `find` or `mod`. All the required scales could also be generated at compile-time.


### Other tracks
8 other tracks implement `scale-generator`:
- [csharp](https://www.github.com/exercism/csharp/tree/master/exercises/scale-generator)
- [elixir](https://www.github.com/exercism/elixir/tree/master/exercises/scale-generator)
- [fsharp](https://www.github.com/exercism/fsharp/tree/master/exercises/scale-generator)
- [go](https://www.github.com/exercism/go/tree/master/exercises/scale-generator)
- [python](https://www.github.com/exercism/python/tree/master/exercises/scale-generator)
- [ruby](https://www.github.com/exercism/ruby/tree/master/exercises/scale-generator)
- [rust](https://www.github.com/exercism/rust/tree/master/exercises/scale-generator)
- [swift](https://www.github.com/exercism/swift/tree/master/exercises/scale-generator)