### PR TITLE
Implement exercise: twelve-days

### DIFF
--- a/config.json
+++ b/config.json
@@ -780,6 +780,18 @@
       ]
     },
     {
+      "slug": "twelve-days",
+      "uuid": "b38a3fcc-f5cf-4366-b0b4-e39b8c81e3f6",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "pattern_recognition",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
       "slug": "binary",
       "uuid": "3acf148d-df9e-4897-8c9f-c17a3ba5e4b6",
       "core": false,

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -1,0 +1,59 @@
+# Twelve Days
+
+Output the lyrics to 'The Twelve Days of Christmas'.
+
+```text
+On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree.
+
+On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the seventh day of Christmas my true love gave to me: seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the eighth day of Christmas my true love gave to me: eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the ninth day of Christmas my true love gave to me: nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the tenth day of Christmas my true love gave to me: ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+```
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r twelve_days_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/twelve-days` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)](http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song))
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/twelve-days/example.nim
+++ b/exercises/twelve-days/example.nim
@@ -1,0 +1,48 @@
+import strformat
+
+type
+  DayRange = range[1..12]
+  DayArray[T] = array[DayRange, T]
+
+const gifts: DayArray[string] = [
+  "a Partridge in a Pear Tree",
+  "two Turtle Doves",
+  "three French Hens",
+  "four Calling Birds",
+  "five Gold Rings",
+  "six Geese-a-Laying",
+  "seven Swans-a-Swimming",
+  "eight Maids-a-Milking",
+  "nine Ladies Dancing",
+  "ten Lords-a-Leaping",
+  "eleven Pipers Piping",
+  "twelve Drummers Drumming"]
+
+const nth: DayArray[string] = [
+  "first", "second", "third", "fourth", "fifth", "sixth",
+  "seventh", "eighth", "ninth", "tenth", "eleventh", "twelfth"]
+
+func generateVerses: tuple[song: string, indices: DayArray[int]] =
+  ## Returns a tuple of:
+  ##   `song`: the song text, including two newlines after every verse.
+  ##   `indices`: the index in `song` of the first character for each verse.
+  for n in nth.low .. nth.high:
+    result.indices[n] = result.song.len
+    result.song &= &"On the {nth[n]} day of Christmas my true love gave to me: "
+    for i in countdown(n, 1):
+      case i
+      of 3..12:
+        result.song &= &"{gifts[i]}, "
+      of 2:
+        result.song &= &"{gifts[i]}, and "
+      of 1:
+        result.song &= &"{gifts[i]}.\n\n"
+
+const pair = generateVerses() # Generate the lyrics at compile-time.
+const song = pair[0] # `const (song, indices) = generateVerses()` in Nim 0.19.9
+const indices = pair[1]
+
+func recite*(start: DayRange, stop = start): string =
+  let firstChar = indices[start]
+  let lastChar = if stop == 12: song.high - 2 else: indices[stop + 1] - 3
+  result = song[firstChar .. lastChar] # Excludes the final two newlines.

--- a/exercises/twelve-days/twelve_days_test.nim
+++ b/exercises/twelve-days/twelve_days_test.nim
@@ -1,0 +1,82 @@
+import unittest
+import twelve_days
+
+# version 1.2.0
+
+suite "Twelve Days":
+  # Single verse: zero newline characters at the end.
+  test "first day a partridge in a pear tree":
+    const expected = "On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree."
+    check recite(1) == expected
+
+  test "second day two turtle doves":
+    const expected = "On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree."
+    check recite(2) == expected
+
+  test "third day three french hens":
+    const expected = "On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+    check recite(3) == expected
+
+  test "fourth day four calling birds":
+    const expected = "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+    check recite(4) == expected
+
+  test "fifth day five gold rings":
+    const expected = "On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+    check recite(5) == expected
+
+  test "sixth day six geese-a-laying":
+    const expected = "On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+    check recite(6) == expected
+
+  test "seventh day seven swans-a-swimming":
+    const expected = "On the seventh day of Christmas my true love gave to me: seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+    check recite(7) == expected
+
+  test "eighth day eight maids-a-milking":
+    const expected = "On the eighth day of Christmas my true love gave to me: eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+    check recite(8) == expected
+
+  test "ninth day nine ladies dancing":
+    const expected = "On the ninth day of Christmas my true love gave to me: nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+    check recite(9) == expected
+
+  test "tenth day ten lords-a-leaping":
+    const expected = "On the tenth day of Christmas my true love gave to me: ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+    check recite(10) == expected
+
+  test "eleventh day eleven pipers piping":
+    const expected = "On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+    check recite(11) == expected
+
+  test "twelfth day twelve drummers drumming":
+    const expected = "On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+    check recite(12) == expected
+
+  # Multiple verses: two newline characters between verses, and zero at the end.
+  test "recites first three verses of the song":
+    const expected = "On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree.\n\n" &
+                     "On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree.\n\n" &
+                     "On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+    check recite(1, 3) == expected
+
+  test "recites three verses from the middle of the song":
+    const expected = "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n\n" &
+                     "On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n\n" &
+                     "On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+    check recite(4, 6) == expected
+
+  test "recites the whole song":
+    const expected = "On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree.\n\n" &
+                     "On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree.\n\n" &
+                     "On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n\n" &
+                     "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n\n" &
+                     "On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n\n" &
+                     "On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n\n" &
+                     "On the seventh day of Christmas my true love gave to me: seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n\n" &
+                     "On the eighth day of Christmas my true love gave to me: eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n\n" &
+                     "On the ninth day of Christmas my true love gave to me: nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n\n" &
+                     "On the tenth day of Christmas my true love gave to me: ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n\n" &
+                     "On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n\n" &
+                     "On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+    check recite(1, 12) == expected


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/twelve-days/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/twelve-days/canonical-data.json)


### Comments
- Similar exercises are `house` (easier) and `food-chain` (harder). Also somewhat similar: `beer-song`, `diamond`, `proverb`.
- This is another exercise that can be computed at compile-time.
- The tests do not check that the user actually generates every verse. The user can hard-code them.
- There are some very long lines in the test file. However, splitting them over multiple lines doesn't really help, and other tracks do the same.


#### Return type
I implement the return type as `string`, not `seq[string]`. This is less elegant (as the user must handle newlines), but it:
- biases the implementation less.
- makes the exercise consistent with `diamond` and `proverb`.
- makes it more interesting to compute at compile-time.
- fits the exercise description better.
- fits `canonical-data.json` better. It contains:
>     "JSON doesn't allow for multi-line strings, so all verses are presented ",
>     "here as arrays of strings. It's up to the test generator to join the ",
>     "lines together with line breaks."


#### Repetition of expected strings
The `expected` string is defined per-test, and not refactored to reduce duplication. This is less elegant, but is done because:
- it has less potential for biasing solutions.
- most tracks do the same (tracks that reduce duplication are `common-lisp` and `go`, and to a lesser extent, `perl5` and `python`).


#### No `join`
The `expected` string for multiple verses is constructed without `join` because:
- it is consistent with `diamond` and `proverb`.
- using `join` might bias users to use it in their own implementation.


#### Function signature
I implement the test for a single verse as `recite(1)`, not `recite(1, 1)`. This allows the user to practise overloading, or using default arguments.


#### Newlines
I implement:
- One verse: no ending newline.
- Multiple verses: two newline between verses, but no final newlines.

The exercise description has two newlines between verses, but out of 11 exercises that use strings, only 4 do this (`java`, `javascript`, `perl5` and `ruby`), and there are 5 different implementations of newlines. I don't think there's an obvious best option. See the table below.


### Other tracks
16 other tracks implement `twelve-days`:

| Track                                                                                                | recite(1)?                 | recite(1, 12)?              | string? | \n       |
| ---------------------------------------------------------------------------------------------------- | -------------------------- | --------------------------- | ------- | --------- |
| [common-lisp](https://www.github.com/exercism/common-lisp/tree/master/exercises/twelve-days)         | ✔                          | ✔                           | ✔       | 0, 1, 0  |
| [csharp](https://www.github.com/exercism/csharp/tree/master/exercises/twelve-days)                   | ✔                          | ✔                           | ✔       | 0, 1, 0  |
| [delphi](https://www.github.com/exercism/delphi/tree/master/exercises/twelve-days)                   | ✔                          | ✔                           | ✔       | 0, 1, 0  |
| [elixir](https://www.github.com/exercism/elixir/tree/master/exercises/twelve-days)                   | verse(1)                   | verses(1, 12)               | ✔       | 0, 1, 0  |
| [elm](https://www.github.com/exercism/elm/tree/master/exercises/twelve-days)                         | recite(1, 1)               | ✔                           |         |          |
| [fsharp](https://www.github.com/exercism/fsharp/tree/master/exercises/twelve-days)                   | recite(1, 1)               | ✔                           |         |          |
| [go](https://www.github.com/exercism/go/tree/master/exercises/twelve-days)                           | Verse(1)                   | Song()                      | ✔       | 0, 1, 1  |
| [haskell](https://www.github.com/exercism/haskell/tree/master/exercises/twelve-days)                 | recite(1, 1)               | ✔                           |         |          |
| [java](https://www.github.com/exercism/java/tree/master/exercises/twelve-days)                       | verse(1)                   | verses(1, 3), sing          | ✔       | 1, 2, 1  |
| [javascript](https://www.github.com/exercism/javascript/tree/master/exercises/twelve-days)           | verse(1)                   | verse(1, 3), sing           | ✔       | 1, 2, 1  |
| [perl5](https://www.github.com/exercism/perl5/tree/master/exercises/twelve-days)                     | verse(1)                   | verses(1, 3), sing          | ✔       | 1, 2, 2  |
| [pharo-smalltalk](https://www.github.com/exercism/pharo-smalltalk/tree/master/exercises/twelve-days) | twelveDaysCalc(1, 1)       | twelveDaysCalc(1, 12)       |          |          |
| [python](https://www.github.com/exercism/python/tree/master/exercises/twelve-days)                   | recite(1, 1)               | ✔                           |         |          |
| [ruby](https://www.github.com/exercism/ruby/tree/master/exercises/twelve-days)                       | verse(1)                   | verses(1, 3), song          | ✔       | 1, 2, 1  |
| [swift](https://www.github.com/exercism/swift/tree/master/exercises/twelve-days)                     | verse(1)                   | verses(1, 3), sing          | ✔       | 0, 1, 1  |
| [typescript](https://www.github.com/exercism/typescript/tree/master/exercises/twelve-days)           | recite(1, 1)               | ✔                           | ✔       | 1, 1, 1  |

where the final column indicates the number of newlines:
- at the end of a single verse
- between multiple verses
- at the end of multiple verses

Remarks:
- `go` has custom error messages.
- `ruby` only tests the whole song, and reads `song.txt` to do so.