### PR TITLE
CI(check_exercises): Support stubs; speed up; improve convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To test a selection of exercises, run:
 $ nim c -r check_exercises.nim [exercise-name] [...]
 ```
 
-This finds all the relevant tests, processes them into a new directory for testing, and runs them. For more information, please read the documentation comments in [`_test/check_exercises.nim`](https://github.com/exercism/nim/blob/master/_test/check_exercises.nim).
+This finds all the relevant tests, processes them into a new directory for testing, and runs them. For more information, please read the documentation comments in [`_test/check_exercises.nim`](https://github.com/exercism/nim/blob/master/_test/check_exercises.nim) or run `check_exercises` with the `--help` option.
 
 ### Nim icon
 The Nim logo is assumed to be owned by Andreas Rumpf. It appears to be released under the MIT license, along with the Nim codebase. We've adapted the official Nim logo by changing the colors, which we believe falls under fair use.

--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ Exercism exercises in Nim
 
 Please see the [contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data)
 
-### How to run exercise's unit tests
+## Testing
 
-The test runner that Travis CI uses is it's own Nim application found at `_test/check_exercises.nim` in the repository. To run the test locally you need to compile the application and then run it.
+The file [`_test/check_exercises.nim`](https://github.com/exercism/nim/blob/master/_test/check_exercises.nim) checks that the example solution for every implemented exercise passes that exercise's test suite. This repo configures Travis CI to run that file, and you can also run it on your own machine.
 
-Then to run all the unit test, run
+To test all the exercises, run:
 ```bash
-$ nim c -r _test/check_exercises.nim
+$ nim c -r check_exercises.nim
 ```
 
-If you would like to run one or more unit test, run
+To test a selection of exercises, run:
 ```bash
-$ nim c -r _test/check_exercises.nim <exercise_name> <exercise_name>
+$ nim c -r check_exercises.nim [exercise-name] [...]
 ```
 
-This will run all the unit tests in the exercise folders, along with renaming the `example.nim` to the appropriate module name to be imported into the unit test. After the test is done, it will rename the file back to `example.nim`. If all test pass, then you will see `SUCCESS` as the last line, if there are any errors you will see `FAILURES` with a list of exercises that have a failing test.
+This finds all the relevant tests, processes them into a new directory for testing, and runs them. For more information, please read the documentation comments in [`_test/check_exercises.nim`](https://github.com/exercism/nim/blob/master/_test/check_exercises.nim).
 
 ### Nim icon
 The Nim logo is assumed to be owned by Andreas Rumpf. It appears to be released under the MIT license, along with the Nim codebase. We've adapted the official Nim logo by changing the colors, which we believe falls under fair use.

--- a/_test/check_exercises.nim
+++ b/_test/check_exercises.nim
@@ -1,42 +1,185 @@
-import
-  os, osproc, strutils, sequtils
+import critbits, os, osproc, parseopt, strutils
 
-type TTestResult = tuple[exercise: string, exitCode: int]
+## This file is for testing the Nim track of exercism.io.
+##
+## It checks that the example solution for every implemented exercise passes
+## that exercise's test suite.
+##
+##
+## Usage
+## =====
+## Test all the exercises:
+## - `nim c -r check_exercises.nim`
+##
+## Test a selection of exercises:
+## - `nim c -r check_exercises.nim [exercise-name] [...]`
+##
+##
+## Implementation
+## ==============
+## Running this file will:
+## 1) Copy tests and examples from the standardized Exercism directory structure
+##    into an output directory with a valid Nimble structure.
+##
+## 2) Write the following files:
+##    - `all_tests.nim` (imports every test).
+##    - `config.nims`   (modifies the path for the tests).
+##
+## 3) Run `all_tests.nim`.
+##
+##
+## Output directory structure
+## ==========================
+## ```
+## check_exercises_tmp
+## ├── src
+## │   └── check_exercises
+## │       ├── acronym.nim
+## │       ...
+## │       └── yacht.nim
+## ├── tests
+## │   ├── all_tests.nim
+## │   ├── config.nims
+## │   ├── test_acronym.nim
+## │   ...
+## │   └── test_yacht.nim
+## ```
 
-proc runTest(testFilePath: string): TTestResult =
-  let
-    exerciseDirPath = os.splitPath(testFilePath)[0]
-    exerciseName = os.splitPath(exerciseDirPath)[1]
-    moduleName = os.splitPath(testFilePath).tail.replace("_test", "")
-    examplePath = os.joinPath(exerciseDirPath, "example.nim")
-    modulePath = os.joinPath(exerciseDirPath, moduleName)
+let
+  appDir = getAppDir()
+  exercisesDir = appDir / "../exercises"
+  outDir = appDir / "check_exercises_tmp"
+  testDir = outDir / "tests"
+  srcDir = outDir / "src" / "check_exercises"
+  allTestsPath = testDir / "all_tests.nim"
 
-  os.copyFile(examplePath, modulePath)
-  echo "\n ### " & exerciseName & " ###"
-  let exitCode = osproc.execCmd("nim c -r --verbosity=0 " & testFilePath)
-  os.removeFile(modulePath)
-  (exerciseName, exitCode)
+# Let us define the exercise names as a set of strings. This is simpler than
+# defining an `enum` of all exercises (or all implemented exercises). We can use
+# `CritBitTree[void]` - an efficient container for a sorted set of strings.
+type
+  Slugs = CritBitTree[void]
+
+proc getImplementedSlugs: Slugs =
+  ## Returns the names of the implemented exercises.
+  ##
+  ## Let us consider an "implemented exercise" as one with a correctly named
+  ## test file, rather than one with an entry in `config.json`. This can be more
+  ## convenient when implementing new exercises.
+  for _, dir in walkDir(exercisesDir):
+    for file in walkFiles(dir / "*_test.nim"):
+      result.incl(dir.splitPath().tail) # e.g. "hello-world"
+
+proc prepareDir =
+  ## Creates the new directory structure for the tests.
+  removeDir(outDir)
+  createDir(testDir)
+  createDir(srcDir)
+  const configFileContents = "--path: \"$projectDir/../src/check_exercises\""
+  writeFile(testDir / "config.nims", configFileContents)
+
+proc wrapTest(file: string, slug: string): string =
+  ## Returns the contents of `file`, but with the tests wrapped inside a proc.
+  ##
+  ## This is a workaround for the "too many global variables" error when running
+  ## many top-level tests with `unittest`. It allows us to keep top-level
+  ## `suite` statements in the repository's test files, which keeps them as
+  ## clear as possible for the user.
+  ##
+  ## We need this workaround as the `suite` and `test` templates in `unittest`
+  ## otherwise put every variable in the global scope, and Nim's GC sets a limit
+  ## of 3500 global variables.
+  var inSuite = false
+  let origFile = readFile(file)
+  let numSuites = origFile.count("\nsuite \"")
+  # Allocate a longer string for the wrapped tests.
+  result = newStringOfCap((origFile.len.float * 1.15).int)
+
+  # Add one indentation layer to all lines from "suite" onwards.
+  for line in lines(file):
+    if line.len == 0:
+      result &= "\n"
+    elif line.startsWith("suite \""):
+      # Put all the tests for an exercise into one suite.
+      if not inSuite:
+        inSuite = true
+        result &= "proc main =\n"
+        result &= "  suite \"" & slug & "\":\n"
+      # If there are multiple suites, keep the suite names as comments only.
+      if numSuites > 1:
+        result &= "    # " & line[7 .. ^3] & "\n"
+    elif inSuite:
+      result &= "  " & line & "\n"
+    else:
+      result &= line & "\n"
+  result &= "\nmain()\n"
+  # The below suppresses an "unused import" warning that is otherwise generated
+  # for each exercise. We run each module's `main` proc when importing, but we
+  # don't export any of its symbols.
+  result &= "{.used.}\n"
+
+proc prepareTests(slugs: Slugs) =
+  ## Copies the example solution and a wrapped test file for the exercises in
+  ## `slugs`, and writes a file that joins all the tests for these exercises.
+  ##
+  ## This allows us to compile `system.nim` and other dependencies only once,
+  ## rather than per-exercise, which fixes the main performance bottleneck when
+  ## testing multiple exercises. It also improves convenience by printing all
+  ## compiler warnings and hints at the top of the output.
+  var allTests = "import ../tests/[\n"
+
+  for slug in slugs:
+    let slugUnder = slug.replace("-", "_")
+    let testName = "test_" & slugUnder # e.g. "test_hello_world"
+    allTests &= "  " & testName & ",\n"
+    let dir = exercisesDir / slug
+
+    # Copy and rename the example solution. For example:
+    #   `exercises/bob/example.nim`  ->  `outDir/src/check_exercises/bob.nim`
+    copyFile(dir / "example.nim", srcDir / slugUnder & ".nim")
+
+    # Copy a wrapped version of the test. For example:
+    #   `exercises/bob/bob_test.nim`  ->  `outDir/tests/test_bob.nim`
+    let wrappedTest = wrapTest(dir / slugUnder & "_test.nim", slug)
+    writeFile(testDir / testName & ".nim", wrappedTest)
+
+  allTests &= "]\n"
+  writeFile(allTestsPath, allTests)
+
+proc runTests(slugs: Slugs): int =
+  ## Runs the tests for the exercises in `slugs`.
+  ##
+  ## Returns the exit code, which is `0` if all tests pass and `1` otherwise.
+  prepareDir()
+  prepareTests(slugs)
+
+  result = execCmd("nim c -r --styleCheck:hint " & allTestsPath)
+  if result == 0:
+    let wording = if slugs.len == 1: " exercise." else: " exercises."
+    echo "\nTested ", slugs.len, wording, "\nAll tests passed."
+  else:
+    echo "\nFailure. At least one test failed."
+
+proc parseCmdLine: Slugs =
+  ## Returns the user-specified exercise slugs.
+  let implementedSlugs = getImplementedSlugs()
+
+  for kind, key, val in getopt():
+    case kind
+    of cmdShortOption, cmdLongOption:
+      discard
+    of cmdArgument:
+      if key in implementedSlugs:
+        result.incl(key) # Test specified exercises in the order given.
+      else:
+        echo "Error: unrecognized exercise name: '" & key & "'"
+        quit(0)
+    of cmdEnd: assert(false) # Cannot happen.
+
+  if result.len == 0:
+    result = implementedSlugs # Test all exercises (in alphabetical order).
 
 when isMainModule:
-  var
-    exercises: seq[string] = @[]
-    failures: seq[string] = @[]
-
-  let arguments = commandLineParams()
-
-  if arguments.len == 0:
-    exercises.add("*")
-  else:
-    exercises = arguments
-
-  for exercise in exercises:
-    for file in os.walkFiles(os.joinPath("./exercises", exercise, "*_test.nim")):
-      let (exercise, exitCode) = runTest(file)
-      if exitCode != 0:
-        failures.add(exercise)
-
-  if failures.len == 0:
-    echo "SUCCESS"
-  else:
-    echo "FAILURES: " & failures.join(", ")
-    programResult = 1
+  let slugs = parseCmdLine()
+  let exitCode = runTests(slugs)
+  if exitCode != 0:
+    quit(exitCode)

--- a/exercises/twelve-days/example.nim
+++ b/exercises/twelve-days/example.nim
@@ -42,7 +42,8 @@ const pair = generateVerses() # Generate the lyrics at compile-time.
 const song = pair[0] # `const (song, indices) = generateVerses()` in Nim 0.19.9
 const indices = pair[1]
 
-func recite*(start: DayRange, stop = start): string =
+func recite*(start: DayRange, stop: DayRange = 1): string =
+  let stop = if stop == 1: start else: stop # Workaround for Nim bug #11274.
   let firstChar = indices[start]
   let lastChar = if stop == 12: song.high - 2 else: indices[stop + 1] - 3
   result = song[firstChar .. lastChar] # Excludes the final two newlines.


### PR DESCRIPTION
This PR rewrites `check_exercises.nim`.

Summary:
- Support stub files.
- Speed up testing of multiple exercises. Testing all exercises is about 7x faster on my machine, and Travis CI builds now take 40–60 seconds, not 2.5–3.5 minutes.
- Add some features that are convenient during development (e.g. `--quiet` mode and abbreviated exercise name arguments).
- Workaround a compiler bug that is triggered by the `twelve-days` example.

See the commit messages for further details.