### PR TITLE
Update tests and READMEs

### DIFF
--- a/exercises/allergies/allergies_test.nim
+++ b/exercises/allergies/allergies_test.nim
@@ -1,69 +1,212 @@
 import unittest
 import allergies
 
-# version 1.2.0
+# version 2.0.0
 
-suite "Allergies":
-  test "no allergies means not allergic":
+suite "Eggs allergy":
+  test "not allergic to anything":
     let allergies = Allergies(score: 0)
-    check allergies.isAllergicTo("peanuts") == false
-    check allergies.isAllergicTo("cats") == false
-    check allergies.isAllergicTo("strawberries") == false
+    check allergies.isAllergicTo("eggs") == false
 
-  test "allergic to eggs":
+  test "allergic only to eggs":
     let allergies = Allergies(score: 1)
     check allergies.isAllergicTo("eggs") == true
 
-  test "allergic to eggs in addition to other stuff":
-    let allergies = Allergies(score: 5)
-    check allergies.isAllergicTo("eggs") == true
-    check allergies.isAllergicTo("shellfish") == true
-    check allergies.isAllergicTo("strawberries") == false
-
-  test "allergic to strawberries but not peanuts":
-    let allergies = Allergies(score: 9)
-    check allergies.isAllergicTo("eggs") == true
-    check allergies.isAllergicTo("peanuts") == false
-    check allergies.isAllergicTo("shellfish") == false
-    check allergies.isAllergicTo("strawberries") == true
-
-  test "no allergies at all":
-    let allergies = Allergies(score: 0)
-    check allergies.lst == newSeq[string](0)
-
-  test "allergic to just eggs":
-    let allergies = Allergies(score: 1)
-    check allergies.lst == @["eggs"]
-
-  test "allergic to just peanuts":
-    let allergies = Allergies(score: 2)
-    check allergies.lst == @["peanuts"]
-
-  test "allergic to just strawberries":
-    let allergies = Allergies(score: 8)
-    check allergies.lst == @["strawberries"]
-
-  test "allergic to eggs and peanuts":
+  test "allergic to eggs and something else":
     let allergies = Allergies(score: 3)
-    check allergies.lst == @["eggs", "peanuts"]
+    check allergies.isAllergicTo("eggs") == true
 
-  test "allergic to more than eggs but not peanuts":
-    let allergies = Allergies(score: 5)
-    check allergies.lst == @["eggs", "shellfish"]
-
-  test "allergic to lots of stuff":
-    let allergies = Allergies(score: 248)
-    check allergies.lst == @[
-      "strawberries", "tomatoes", "chocolate", "pollen", "cats"]
+  test "allergic to something, but not eggs":
+    let allergies = Allergies(score: 2)
+    check allergies.isAllergicTo("eggs") == false
 
   test "allergic to everything":
     let allergies = Allergies(score: 255)
-    check allergies.lst == @[
-      "eggs", "peanuts", "shellfish", "strawberries", "tomatoes",
-      "chocolate", "pollen", "cats"]
+    check allergies.isAllergicTo("eggs") == true
 
-  test "ignore non allergen score parts":
+suite "Peanuts allergy":
+  test "not allergic to anything":
+    let allergies = Allergies(score: 0)
+    check allergies.isAllergicTo("peanuts") == false
+
+  test "allergic only to peanuts":
+    let allergies = Allergies(score: 2)
+    check allergies.isAllergicTo("peanuts") == true
+
+  test "allergic to peanuts and something else":
+    let allergies = Allergies(score: 7)
+    check allergies.isAllergicTo("peanuts") == true
+
+  test "allergic to something, but not peanuts":
+    let allergies = Allergies(score: 5)
+    check allergies.isAllergicTo("peanuts") == false
+
+  test "allergic to everything":
+    let allergies = Allergies(score: 255)
+    check allergies.isAllergicTo("peanuts") == true
+
+suite "Shellfish allergy":
+  test "not allergic to anything":
+    let allergies = Allergies(score: 0)
+    check allergies.isAllergicTo("shellfish") == false
+
+  test "allergic only to shellfish":
+    let allergies = Allergies(score: 4)
+    check allergies.isAllergicTo("shellfish") == true
+
+  test "allergic to shellfish and something else":
+    let allergies = Allergies(score: 14)
+    check allergies.isAllergicTo("shellfish") == true
+
+  test "allergic to something, but not shellfish":
+    let allergies = Allergies(score: 10)
+    check allergies.isAllergicTo("shellfish") == false
+
+  test "allergic to everything":
+    let allergies = Allergies(score: 255)
+    check allergies.isAllergicTo("shellfish") == true
+
+suite "Strawberries allergy":
+  test "not allergic to anything":
+    let allergies = Allergies(score: 0)
+    check allergies.isAllergicTo("strawberries") == false
+
+  test "allergic only to strawberries":
+    let allergies = Allergies(score: 8)
+    check allergies.isAllergicTo("strawberries") == true
+
+  test "allergic to strawberries and something else":
+    let allergies = Allergies(score: 28)
+    check allergies.isAllergicTo("strawberries") == true
+
+  test "allergic to something, but not strawberries":
+    let allergies = Allergies(score: 20)
+    check allergies.isAllergicTo("strawberries") == false
+
+  test "allergic to everything":
+    let allergies = Allergies(score: 255)
+    check allergies.isAllergicTo("strawberries") == true
+
+suite "Tomatoes allergy":
+  test "not allergic to anything":
+    let allergies = Allergies(score: 0)
+    check allergies.isAllergicTo("tomatoes") == false
+
+  test "allergic only to tomatoes":
+    let allergies = Allergies(score: 16)
+    check allergies.isAllergicTo("tomatoes") == true
+
+  test "allergic to tomatoes and something else":
+    let allergies = Allergies(score: 56)
+    check allergies.isAllergicTo("tomatoes") == true
+
+  test "allergic to something, but not tomatoes":
+    let allergies = Allergies(score: 40)
+    check allergies.isAllergicTo("tomatoes") == false
+
+  test "allergic to everything":
+    let allergies = Allergies(score: 255)
+    check allergies.isAllergicTo("tomatoes") == true
+
+suite "Chocolate allergy":
+  test "not allergic to anything":
+    let allergies = Allergies(score: 0)
+    check allergies.isAllergicTo("chocolate") == false
+
+  test "allergic only to chocolate":
+    let allergies = Allergies(score: 32)
+    check allergies.isAllergicTo("chocolate") == true
+
+  test "allergic to chocolate and something else":
+    let allergies = Allergies(score: 112)
+    check allergies.isAllergicTo("chocolate") == true
+
+  test "allergic to something, but not chocolate":
+    let allergies = Allergies(score: 80)
+    check allergies.isAllergicTo("chocolate") == false
+
+  test "allergic to everything":
+    let allergies = Allergies(score: 255)
+    check allergies.isAllergicTo("chocolate") == true
+
+suite "Pollen allergy":
+  test "not allergic to anything":
+    let allergies = Allergies(score: 0)
+    check allergies.isAllergicTo("pollen") == false
+
+  test "allergic only to pollen":
+    let allergies = Allergies(score: 64)
+    check allergies.isAllergicTo("pollen") == true
+
+  test "allergic to pollen and something else":
+    let allergies = Allergies(score: 224)
+    check allergies.isAllergicTo("pollen") == true
+
+  test "allergic to something, but not pollen":
+    let allergies = Allergies(score: 160)
+    check allergies.isAllergicTo("pollen") == false
+
+  test "allergic to everything":
+    let allergies = Allergies(score: 255)
+    check allergies.isAllergicTo("pollen") == true
+
+suite "Cats allergy":
+  test "not allergic to anything":
+    let allergies = Allergies(score: 0)
+    check allergies.isAllergicTo("cats") == false
+
+  test "allergic only to cats":
+    let allergies = Allergies(score: 128)
+    check allergies.isAllergicTo("cats") == true
+
+  test "allergic to cats and something else":
+    let allergies = Allergies(score: 192)
+    check allergies.isAllergicTo("cats") == true
+
+  test "allergic to something, but not cats":
+    let allergies = Allergies(score: 64)
+    check allergies.isAllergicTo("cats") == false
+
+  test "allergic to everything":
+    let allergies = Allergies(score: 255)
+    check allergies.isAllergicTo("cats") == true
+
+suite "List the allergies":
+  test "no allergies":
+    let allergies = Allergies(score: 0)
+    check allergies.lst.len == 0
+
+  test "just eggs":
+    let allergies = Allergies(score: 1)
+    check allergies.lst == @["eggs"]
+
+  test "just peanuts":
+    let allergies = Allergies(score: 2)
+    check allergies.lst == @["peanuts"]
+
+  test "just strawberries":
+    let allergies = Allergies(score: 8)
+    check allergies.lst == @["strawberries"]
+
+  test "eggs and peanuts":
+    let allergies = Allergies(score: 3)
+    check allergies.lst == @["eggs", "peanuts"]
+
+  test "more than eggs but not peanuts":
+    let allergies = Allergies(score: 5)
+    check allergies.lst == @["eggs", "shellfish"]
+
+  test "lots of stuff":
+    let allergies = Allergies(score: 248)
+    check allergies.lst == @["strawberries", "tomatoes", "chocolate",
+                             "pollen", "cats"]
+
+  test "everything":
+    let allergies = Allergies(score: 255)
+    check allergies.lst == @["eggs", "peanuts", "shellfish", "strawberries",
+                             "tomatoes", "chocolate", "pollen", "cats"]
+
+  test "no allergen score parts":
     let allergies = Allergies(score: 509)
-    check allergies.lst == @[
-      "eggs", "shellfish", "strawberries", "tomatoes", "chocolate",
-      "pollen", "cats"]
+    check allergies.lst == @["eggs", "shellfish", "strawberries", "tomatoes",
+                             "chocolate", "pollen", "cats"]

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -1,6 +1,7 @@
 # Anagram
 
-Given a word and a list of possible anagrams, select the correct sublist.
+An anagram is a rearrangement of letters to form a new word.
+Given a word and a list of candidates, select the sublist of anagrams of the given word.
 
 Given `"listen"` and a list of candidates like `"enlists" "google"
 "inlets" "banana"` the program should return a list containing

--- a/exercises/anagram/anagram_test.nim
+++ b/exercises/anagram/anagram_test.nim
@@ -1,7 +1,7 @@
 import unittest
 import anagram
 
-# version 1.4.0
+# version 1.5.0
 
 suite "Anagram":
   test "no matches":
@@ -29,6 +29,11 @@ suite "Anagram":
     const candidates = @["gallery", "ballerina", "regally", "clergy", "largely", "leading"]
     check detectAnagrams(word, candidates) == @["gallery", "regally", "largely"]
 
+  test "detects multiple anagrams with different case":
+    const word = "nose"
+    const candidates = @["Eons", "ONES"]
+    check detectAnagrams(word, candidates) == @["Eons", "ONES"]
+
   test "does not detect non-anagrams with identical checksum":
     const word = "mass"
     const candidates = @["last"]
@@ -49,7 +54,7 @@ suite "Anagram":
     const candidates = @["cashregister", "Carthorse", "radishes"]
     check detectAnagrams(word, candidates) == @["Carthorse"]
 
-  test "does not detect a anagram if the original word is repeated":
+  test "does not detect an anagram if the original word is repeated":
     const word = "go"
     const candidates = @["go Go GO"]
     check detectAnagrams(word, candidates).len == 0
@@ -63,3 +68,8 @@ suite "Anagram":
     const word = "BANANA"
     const candidates = @["BANANA", "Banana", "banana"]
     check detectAnagrams(word, candidates).len == 0
+
+  test "words other than themselves can be anagrams":
+    const word = "LISTEN"
+    const candidates = @["Listen", "Silent", "LISTEN"]
+    check detectAnagrams(word, candidates) == @["Silent"]

--- a/exercises/anagram/anagram_test.nim
+++ b/exercises/anagram/anagram_test.nim
@@ -5,98 +5,61 @@ import anagram
 
 suite "Anagram":
   test "no matches":
-    let
-      word = "diaper"
-      candidates = @["hello", "world", "zombies", "pants"]
-      expected: seq[string] = @[]
-      detected = detectAnagrams(word, candidates)
-    check detected == expected
+    const word = "diaper"
+    const candidates = @["hello", "world", "zombies", "pants"]
+    check detectAnagrams(word, candidates).len == 0
 
   test "detects two anagrams":
-    let
-      word = "master"
-      candidates = @["stream", "pigeon", "maters"]
-      expected = @["stream", "maters"]
-      detected = detectAnagrams(word, candidates)
-    check detected == expected
+    const word = "master"
+    const candidates = @["stream", "pigeon", "maters"]
+    check detectAnagrams(word, candidates) == @["stream", "maters"]
 
   test "does not detect anagram subsets":
-    let
-      word = "good"
-      candidates = @["dog", "goody"]
-      expected: seq[string] = @[]
-      detected = detectAnagrams(word, candidates)
-    check detected == expected
+    const word = "good"
+    const candidates = @["dog", "goody"]
+    check detectAnagrams(word, candidates).len == 0
 
   test "detects anagram":
-    let
-      word = "listen"
-      candidates = @["enlists", "google", "inlets", "banana"]
-      expected = @["inlets"]
-      detected = detectAnagrams(word, candidates)
-    check detected == expected
+    const word = "listen"
+    const candidates = @["enlists", "google", "inlets", "banana"]
+    check detectAnagrams(word, candidates) == @["inlets"]
 
   test "detects three anagrams":
-    let
-      word = "allergy"
-      candidates = @["gallery", "ballerina", "regally",
-                     "clergy", "largely", "leading"]
-      expected = @["gallery", "regally", "largely"]
-      detected = detectAnagrams(word, candidates)
-    check detected == expected
+    const word = "allergy"
+    const candidates = @["gallery", "ballerina", "regally", "clergy", "largely", "leading"]
+    check detectAnagrams(word, candidates) == @["gallery", "regally", "largely"]
 
   test "does not detect non-anagrams with identical checksum":
-    let
-      word = "mass"
-      candidates = @["last"]
-      expected: seq[string] = @[]
-      detected = detectAnagrams(word, candidates)
-    check detected == expected
+    const word = "mass"
+    const candidates = @["last"]
+    check detectAnagrams(word, candidates).len == 0
 
   test "detects anagrams case-insensitively":
-    let
-      word = "Orchestra"
-      candidates = @["cashregister", "Carthorse", "radishes"]
-      expected = @["Carthorse"]
-      detected = detectAnagrams(word, candidates)
-    check detected == expected
+    const word = "Orchestra"
+    const candidates = @["cashregister", "Carthorse", "radishes"]
+    check detectAnagrams(word, candidates) == @["Carthorse"]
 
   test "detects anagrams using case-insensitive subject":
-    let
-      word = "Orchestra"
-      candidates = @["cashregister", "carthorse", "radishes"]
-      expected = @["carthorse"]
-      detected = detectAnagrams(word, candidates)
-    check detected == expected
+    const word = "Orchestra"
+    const candidates = @["cashregister", "carthorse", "radishes"]
+    check detectAnagrams(word, candidates) == @["carthorse"]
 
   test "detects anagrams using case-insensitive possible matches":
-    let
-      word = "orchestra"
-      candidates = @["cashregister", "Carthorse", "radishes"]
-      expected = @["Carthorse"]
-      detected = detectAnagrams(word, candidates)
-    check detected == expected
+    const word = "orchestra"
+    const candidates = @["cashregister", "Carthorse", "radishes"]
+    check detectAnagrams(word, candidates) == @["Carthorse"]
 
   test "does not detect a anagram if the original word is repeated":
-    let
-      word = "go"
-      candidates = @["go Go GO"]
-      expected: seq[string] = @[]
-      detected = detectAnagrams(word, candidates)
-    check detected == expected
+    const word = "go"
+    const candidates = @["go Go GO"]
+    check detectAnagrams(word, candidates).len == 0
 
   test "anagrams must use all letters exactly once":
-    let
-      word = "tapper"
-      candidates = @["patter"]
-      expected: seq[string] = @[]
-      detected = detectAnagrams(word, candidates)
-    check detected == expected
+    const word = "tapper"
+    const candidates = @["patter"]
+    check detectAnagrams(word, candidates).len == 0
 
   test "words are not anagrams of themselves (case-insensitive)":
-    let
-      word = "BANANA"
-      candidates = @["BANANA", "Banana", "banana"]
-      expected: seq[string] = @[]
-      detected = detectAnagrams(word, candidates)
-    check detected == expected
+    const word = "BANANA"
+    const candidates = @["BANANA", "Banana", "banana"]
+    check detectAnagrams(word, candidates).len == 0

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -2,9 +2,9 @@
 
 Bob is a lackadaisical teenager. In conversation, his responses are very limited.
 
-Bob answers 'Sure.' if you ask him a question.
+Bob answers 'Sure.' if you ask him a question, such as "How are you?".
 
-He answers 'Whoa, chill out!' if you yell at him.
+He answers 'Whoa, chill out!' if you YELL AT HIM (in all capitals).
 
 He answers 'Calm down, I know what I'm doing!' if you yell a question at him.
 

--- a/exercises/darts/README.md
+++ b/exercises/darts/README.md
@@ -39,7 +39,7 @@ These guides should help you,
 
 ## Source
 
-Inspired by an excersie created by a professor Della Paolera in Argentina
+Inspired by an exercise created by a professor Della Paolera in Argentina
 
 ## Submitting Incomplete Solutions
 

--- a/exercises/darts/darts_test.nim
+++ b/exercises/darts/darts_test.nim
@@ -1,26 +1,44 @@
 import unittest
 import darts
 
-# version 1.1.0
+# version 2.2.0
 
 suite "Darts":
-  test "A dart lands outside the target":
+  test "missed target":
     check score((-9.0, 9.0)) == 0
 
-  test "A dart lands just in the border of the target":
+  test "on the outer circle":
     check score((0.0, 10.0)) == 1
 
-  test "A dart lands in the outer circle":
-    check score((4.0, 4.0)) == 1
+  test "on the middle circle":
+    check score((-5.0, 0.0)) == 5
 
-  test "A dart lands right in the border between outer and middle circles":
-    check score((5.0, 0.0)) == 5
-
-  test "A dart lands in the middle circle":
-    check score((0.8, -0.8)) == 5
-
-  test "A dart lands right in the border between middle and inner circles":
+  test "on the inner circle":
     check score((0.0, -1.0)) == 10
 
-  test "A dart lands in the inner circle":
+  test "exactly on centre":
+    check score((0.0, 0.0)) == 10
+
+  test "near the centre":
     check score((-0.1, -0.1)) == 10
+
+  test "just within the inner circle":
+    check score((0.7, 0.7)) == 10
+
+  test "just outside the inner circle":
+    check score((0.8, -0.8)) == 5
+
+  test "just within the middle circle":
+    check score((-3.5, 3.5)) == 5
+
+  test "just outside the middle circle":
+    check score((-3.6, -3.6)) == 1
+
+  test "just within the outer circle":
+    check score((-7.0, 7.0)) == 1
+
+  test "just outside the outer circle":
+    check score((7.1, -7.1)) == 0
+
+  test "asymmetric position between the inner and middle circles":
+    check score((0.5, -4.0)) == 5

--- a/exercises/etl/etl_test.nim
+++ b/exercises/etl/etl_test.nim
@@ -1,10 +1,10 @@
 import unittest, tables
 import etl
 
-# version 1.0.0
+# version 2.0.0
 
 suite "ETL":
-  test "a single score with a single letter":
+  test "single letter":
     const input = {
       1: @['A']
     }.toTable
@@ -13,7 +13,7 @@ suite "ETL":
       output.len == 1
       output['a'] == 1
 
-  test "a single score with multiple letters":
+  test "single score with multiple letters":
     const input = {
       1: @['A', 'E', 'I', 'O', 'U']
     }.toTable

--- a/exercises/etl/etl_test.nim
+++ b/exercises/etl/etl_test.nim
@@ -35,8 +35,8 @@ suite "ETL":
     check:
       output.len == 4
       output['a'] == 1
-      output['e'] == 1
       output['d'] == 2
+      output['e'] == 1
       output['g'] == 2
 
   test "multiple scores with differing numbers of letters":

--- a/exercises/leap/leap_test.nim
+++ b/exercises/leap/leap_test.nim
@@ -1,23 +1,23 @@
 import unittest
 import leap
 
-# version 1.5.0
+# version 1.5.1
 
 suite "Leap":
-  test "year not divisible by 4: common year":
+  test "year not divisible by 4 in common year":
     check isLeapYear(2015) == false
 
-  test "year divisible by 2, not divisible by 4: common year":
+  test "year divisible by 2, not divisible by 4 in common year":
     check isLeapYear(1970) == false
 
-  test "year divisible by 4, not divisible by 100: leap year":
+  test "year divisible by 4, not divisible by 100 in leap year":
     check isLeapYear(1996) == true
 
-  test "year divisible by 100, not divisible by 400: common year":
+  test "year divisible by 100, not divisible by 400 in common year":
     check isLeapYear(2100) == false
 
-  test "year divisible by 400: leap year":
+  test "year divisible by 400 in leap year":
     check isLeapYear(2000) == true
 
-  test "year divisible by 200, not divisible by 400: common year":
+  test "year divisible by 200, not divisible by 400 in common year":
     check isLeapYear(1800) == false

--- a/exercises/luhn/luhn_test.nim
+++ b/exercises/luhn/luhn_test.nim
@@ -1,7 +1,7 @@
 import unittest
 import luhn
 
-# version 1.4.0
+# version 1.6.1
 
 suite "Luhn":
   test "single digit strings can not be valid":
@@ -28,8 +28,8 @@ suite "Luhn":
   test "valid number with an even number of digits":
     check isValid("095 245 88") == true
 
-  test "valid strings with a non-digit included become invalid":
-    check isValid("055a 444 285") == false
+  test "valid number with an odd number of spaces":
+    check isValid("234 567 891 234") == true
 
   test "valid strings with a non-digit added at the end become invalid":
     check isValid("059a") == false
@@ -38,7 +38,7 @@ suite "Luhn":
     check isValid("055-444-285") == false
 
   test "valid strings with symbols included become invalid":
-    check isValid("055£ 444$ 285") == false
+    check isValid("055# 444$ 285") == false
 
   test "single zero with space is invalid":
     check isValid(" 0") == false
@@ -49,5 +49,8 @@ suite "Luhn":
   test "input digit 9 is correctly converted to output digit 9":
     check isValid("091") == true
 
-  test "strings with non-digits is invalid":
+  test "using ascii value for non-doubled non-digit isn't allowed":
+    check isValid("055b 444 285") == false
+
+  test "using ascii value for doubled non-digit isn't allowed":
     check isValid(":9") == false

--- a/exercises/pangram/pangram_test.nim
+++ b/exercises/pangram/pangram_test.nim
@@ -1,35 +1,35 @@
 import unittest
 import pangram
 
-# version 1.4.1
+# version 2.0.0
 
 suite "Pangram":
-  test "sentence empty":
+  test "empty sentence":
     check isPangram("") == false
 
-  test "recognizes a perfect lower case pangram":
+  test "perfect lower case":
     check isPangram("abcdefghijklmnopqrstuvwxyz") == true
 
-  test "pangram with only lower case":
+  test "only lower case":
     check isPangram("the quick brown fox jumps over the lazy dog") == true
 
-  test "missing character 'x'":
+  test "missing the letter 'x'":
     check isPangram("a quick movement of the enemy will jeopardize five gunboats") == false
 
-  test "another missing character, e.g. 'h'":
+  test "missing the letter 'h'":
     check isPangram("five boxing wizards jump quickly at it") == false
 
-  test "pangram with underscores":
+  test "with underscores":
     check isPangram("the_quick_brown_fox_jumps_over_the_lazy_dog") == true
 
-  test "pangram with numbers":
+  test "with numbers":
     check isPangram("the 1 quick brown fox jumps over the 2 lazy dogs") == true
 
   test "missing letters replaced by numbers":
     check isPangram("7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog") == false
 
-  test "pangram with mixed case and punctuation":
+  test "mixed case and punctuation":
     check isPangram("\"Five quacking Zephyrs jolt my wax bed.\"") == true
 
-  test "upper and lower case versions of the same character should not be counted separately":
+  test "case insensitive":
     check isPangram("the quick brown fox jumps over with lazy FX") == false

--- a/exercises/queen-attack/queen_attack_test.nim
+++ b/exercises/queen-attack/queen_attack_test.nim
@@ -1,7 +1,7 @@
 import unittest
 import queen_attack
 
-# version 2.2.0
+# version 2.3.0
 
 suite "Queen Attack":
   # Raise an error for invalid positions
@@ -42,7 +42,7 @@ suite "Queen Attack":
     check canAttack((2, 2), (1, 1)) == true
 
   test "can attack on fourth diagonal":
-    check canAttack((2, 2), (5, 5)) == true
+    check canAttack((1, 7), (0, 6)) == true
 
 
   # Bonus: graphical board representation

--- a/exercises/reverse-string/reverse_string_test.nim
+++ b/exercises/reverse-string/reverse_string_test.nim
@@ -1,7 +1,7 @@
 import unittest
 import reverse_string
 
-# version 1.1.0
+# version 1.2.0
 
 suite "Reverse String":
   test "an empty string":
@@ -18,3 +18,6 @@ suite "Reverse String":
 
   test "a palindrome":
     check reverse("racecar") == "racecar"
+
+  test "an even-sized word":
+    check reverse("drawer") == "reward"

--- a/exercises/triangle/triangle_test.nim
+++ b/exercises/triangle/triangle_test.nim
@@ -1,57 +1,57 @@
 import unittest
 import triangle
 
-# version 1.2.0
+# version 1.2.1
 
-suite "returns true if the triangle is equilateral":
-  test "true if all sides are equal":
+suite "Equilateral triangle":
+  test "all sides are equal":
     check isEquilateral([2, 2, 2]) == true
 
-  test "false if any side is unequal":
+  test "any side is unequal":
     check isEquilateral([2, 3, 2]) == false
 
-  test "false if no sides are equal":
+  test "no sides are equal":
     check isEquilateral([5, 4, 6]) == false
 
-  test "false if all sides are zero":
+  test "all zero sides is not a triangle":
     check isEquilateral([0, 0, 0]) == false
 
 
-suite "returns true if the triangle is isosceles":
-  test "true if last two sides are equal":
+suite "Isosceles triangle":
+  test "last two sides are equal":
     check isIsosceles([3, 4, 4]) == true
 
-  test "true if first two sides are equal":
+  test "first two sides are equal":
     check isIsosceles([4, 4, 3]) == true
 
-  test "true if first and last sides are equal":
+  test "first and last sides are equal":
     check isIsosceles([4, 3, 4]) == true
 
   test "equilateral triangles are also isosceles":
     check isIsosceles([4, 4, 4]) == true
 
-  test "false if no sides are equal":
+  test "no sides are equal":
     check isIsosceles([2, 3, 4]) == false
 
-  test "false if sides violate triangle inequality, even if two are equal (1)":
+  test "first triangle inequality violation":
     check isIsosceles([1, 1, 3]) == false
 
-  test "false if sides violate triangle inequality, even if two are equal (2)":
+  test "second triangle inequality violation":
     check isIsosceles([1, 3, 1]) == false
 
-  test "false if sides violate triangle inequality, even if two are equal (3)":
+  test "third triangle inequality violation":
     check isIsosceles([3, 1, 1]) == false
 
 
-suite "returns true if the triangle is scalene":
-  test "true if no sides are equal":
+suite "Scalene triangle":
+  test "no sides are equal":
     check isScalene([5, 4, 6]) == true
 
-  test "false if all sides are equal":
+  test "all sides are equal":
     check isScalene([4, 4, 4]) == false
 
-  test "false if two sides are equal":
+  test "two sides are equal":
     check isScalene([4, 4, 3]) == false
 
-  test "false if sides violate triangle inequality, even if they are all different":
+  test "may not violate triangle inequality":
     check isScalene([7, 3, 2]) == false

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -18,12 +18,12 @@ One for you, one for me.
 
 Here are some examples:
 
-|Name    | String to return 
-|:------:|:-----------------: 
-|Alice   | One for Alice, one for me. 
-|Bob     | One for Bob, one for me.
-|        | One for you, one for me.
-|Zaphod  | One for Zaphod, one for me.
+|Name    |String to return 
+|:-------|:------------------
+|Alice   |One for Alice, one for me. 
+|Bob     |One for Bob, one for me.
+|        |One for you, one for me.
+|Zaphod  |One for Zaphod, one for me.
 
 ## Running the tests
 

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -1,14 +1,33 @@
 # Word Count
 
-Given a phrase, count the occurrences of each word in that phrase.
+Given a phrase, count the occurrences of each _word_ in that phrase.
 
-For example for the input `"olly olly in come free"`
+For the purposes of this exercise you can expect that a _word_ will always be one of:
+
+1. A _number_ composed of one or more ASCII digits (ie "0" or "1234") OR
+2. A _simple word_ composed of one or more ASCII letters (ie "a" or "they") OR
+3. A _contraction_ of two _simple words_ joined by a single apostrophe (ie "it's" or "they're")
+
+When counting words you can assume the following rules:
+
+1. The count is _case insensitive_ (ie "You", "you", and "YOU" are 3 uses of the same word)
+2. The count is _unordered_; the tests will ignore how words and counts are ordered
+3. Other than the apostrophe in a _contraction_ all forms of _punctuation_ are ignored
+4. The words can be separated by _any_ form of whitespace (ie "\t", "\n", " ")
+
+For example, for the phrase `"That's the password: 'PASSWORD 123'!", cried the Special Agent.\nSo I fled.` the count would be:
 
 ```text
-olly: 2
-in: 1
-come: 1
-free: 1
+that's: 1
+the: 2
+password: 2
+123: 1
+cried: 1
+special: 1
+agent: 1
+so: 1
+i: 1
+fled: 1
 ```
 
 The return from `countWords` can be any hash table type with a key of `string` and a value of `int`.


### PR DESCRIPTION
(Do not squash).

This PR brings the track up-to-date by updating tests and READMEs.

I use only one PR here because:
- The commits have the same purpose (apart from two minor refactorings).
- It allows the updates to be merged in chronological order (by date of upstream change).
- It helps the refactorings to be merged before the updates.
- Travis only needs to run once.
- Most of the changes are trivial.

The updates to tests in this PR correspond to the following upstream changes:

| Exercise       |                                                                                                                                                   |                                                                                                                                                   |                                                                                                                                                   |                                                                                                                                                   |
| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
| allergies      | [2.0.0](https://github.com/exercism/problem-specifications/commit/ca9c09eda445e642317a043bf9c949fbffae4020#diff-66aee87a45b7fa46f2220acd430bf284) |                                                                                                                                                   |                                                                                                                                                   |                                                                                                                                                   |
| anagram        | [1.4.1](https://github.com/exercism/problem-specifications/commit/1add7644b75fa26e524668eb1013d53e330f143c#diff-455d887764697eedf47c8297997dc4ff) | [1.5.0](https://github.com/exercism/problem-specifications/commit/49a36feb1a1ef3f9262b98f34e78cdddb654cd6d#diff-455d887764697eedf47c8297997dc4ff) |                                                                                                                                                   |                                                                                                                                                   |
| darts          | [1.2.0](https://github.com/exercism/problem-specifications/commit/bac9381d071caf437b68c1b4cd08ad9841b9ecf7#diff-f6e829e76c970b79422c9ab93aa9935d) | [2.0.0](https://github.com/exercism/problem-specifications/commit/efcb2c85d31b6cef45f6d2c893cd35326a5eb8de#diff-f6e829e76c970b79422c9ab93aa9935d) | [2.1.0](https://github.com/exercism/problem-specifications/commit/c5a1b8b75fb7337416abf4dd4b16d259a63c3f7b#diff-f6e829e76c970b79422c9ab93aa9935d) | [2.2.0](https://github.com/exercism/problem-specifications/commit/212baa3cd18159fbdcf7098c9587f63a2dc2f556#diff-f6e829e76c970b79422c9ab93aa9935d) |
| etl            | [1.0.1](https://github.com/exercism/problem-specifications/commit/df8331a8ad1682f4c394bad3f88a6b47a91ec609#diff-aeb9718fac0db20e378972b68f62327e) | [2.0.0](https://github.com/exercism/problem-specifications/commit/47a0970422bd02f1f8a4d09b53fcee798d304e6d#diff-aeb9718fac0db20e378972b68f62327e) |                                                                                                                                                   |                                                                                                                                                   |
| leap           | [1.5.1](https://github.com/exercism/problem-specifications/commit/18875ece112eb46c7227e7e1745432ed16030ddd#diff-6a420fb8309273321227d40638d4767e) |                                                                                                                                                   |                                                                                                                                                   |                                                                                                                                                   |
| luhn           | [1.5.0](https://github.com/exercism/problem-specifications/commit/6aa07c967fc3e44c17b94fd9ae99bf88ad954434#diff-8f94f171222caa1afb36e9a0db9811f2) | [1.6.0](https://github.com/exercism/problem-specifications/commit/d7fdadc4d8f6e2b7d9b2115376c8f59d9dff4840#diff-8f94f171222caa1afb36e9a0db9811f2) | [1.6.1](https://github.com/exercism/problem-specifications/commit/f375a46c1e3d50ecd0347ab1dfc8bbdafc8817c7#diff-8f94f171222caa1afb36e9a0db9811f2) |                                                                                                                                                   |
| pangram        | [2.0.0](https://github.com/exercism/problem-specifications/commit/f68b632f2578d9969074657d764b32f61f53c008#diff-98967529f5adf348fce12448bdd991a7) |                                                                                                                                                   |                                                                                                                                                   |                                                                                                                                                   |
| queen-attack   | [2.3.0](https://github.com/exercism/problem-specifications/commit/f0fa3fc4fdb96637a19ddcf4d040564b1790664d#diff-96b36309ff1b4f05ed51e0af6563ed56) |                                                                                                                                                   |                                                                                                                                                   |                                                                                                                                                   |
| reverse-string | [1.2.0](https://github.com/exercism/problem-specifications/commit/6c95c2e50fb4cda7dfcc83de220dd3467d788007#diff-2a1842fc88fd3f4b997b5bca8868e333) |                                                                                                                                                   |                                                                                                                                                   |                                                                                                                                                   |
| triangle       | [1.2.1](https://github.com/exercism/problem-specifications/commit/c652ec2529486b87e7786073cf62121f6aa9a8a9#diff-a26a784922d57d5d3922ff5520be72a4) |                                                                                                                                                   |                                                                                                                                                   |                                                                                                                                                   |


### Biggest change: allergies
The biggest change is to `allergies`. There is now a question of how many suites to use.

I think the last option of the below is best, otherwise there are many duplicate test names of
> `not allergic to anything`

and

> `allergic to everything`


#### One suite
```
[Suite] Allergies
  [OK] not allergic to anything
  [OK] allergic only to eggs
  [OK] allergic to eggs and something else
  [OK] allergic to something, but not eggs
  [OK] allergic to everything
  [OK] not allergic to anything
  [OK] allergic only to peanuts
  [OK] allergic to peanuts and something else
  [OK] allergic to something, but not peanuts
  [OK] allergic to everything
  [OK] not allergic to anything
  [OK] allergic only to shellfish
  [OK] allergic to shellfish and something else
  [OK] allergic to something, but not shellfish
  [OK] allergic to everything
  [OK] not allergic to anything
  [OK] allergic only to strawberries
  [OK] allergic to strawberries and something else
  [OK] allergic to something, but not strawberries
  [OK] allergic to everything
  [OK] not allergic to anything
  [OK] allergic only to tomatoes
  [OK] allergic to tomatoes and something else
  [OK] allergic to something, but not tomatoes
  [OK] allergic to everything
  [OK] not allergic to anything
  [OK] allergic only to chocolate
  [OK] allergic to chocolate and something else
  [OK] allergic to something, but not chocolate
  [OK] allergic to everything
  [OK] not allergic to anything
  [OK] allergic only to pollen
  [OK] allergic to pollen and something else
  [OK] allergic to something, but not pollen
  [OK] allergic to everything
  [OK] not allergic to anything
  [OK] allergic only to cats
  [OK] allergic to cats and something else
  [OK] allergic to something, but not cats
  [OK] allergic to everything
  [OK] no allergies
  [OK] just eggs
  [OK] just peanuts
  [OK] just strawberries
  [OK] eggs and peanuts
  [OK] more than eggs but not peanuts
  [OK] lots of stuff
  [OK] everything
  [OK] no allergen score parts
```

#### Two suites
```
[Suite] Individual allergens
  [OK] not allergic to anything
  [OK] allergic only to eggs
  [OK] allergic to eggs and something else
  [OK] allergic to something, but not eggs
  [OK] allergic to everything
  [OK] not allergic to anything
  [OK] allergic only to peanuts
  [OK] allergic to peanuts and something else
  [OK] allergic to something, but not peanuts
  [OK] allergic to everything
  [OK] not allergic to anything
  [OK] allergic only to shellfish
  [OK] allergic to shellfish and something else
  [OK] allergic to something, but not shellfish
  [OK] allergic to everything
  [OK] not allergic to anything
  [OK] allergic only to strawberries
  [OK] allergic to strawberries and something else
  [OK] allergic to something, but not strawberries
  [OK] allergic to everything
  [OK] not allergic to anything
  [OK] allergic only to tomatoes
  [OK] allergic to tomatoes and something else
  [OK] allergic to something, but not tomatoes
  [OK] allergic to everything
  [OK] not allergic to anything
  [OK] allergic only to chocolate
  [OK] allergic to chocolate and something else
  [OK] allergic to something, but not chocolate
  [OK] allergic to everything
  [OK] not allergic to anything
  [OK] allergic only to pollen
  [OK] allergic to pollen and something else
  [OK] allergic to something, but not pollen
  [OK] allergic to everything
  [OK] not allergic to anything
  [OK] allergic only to cats
  [OK] allergic to cats and something else
  [OK] allergic to something, but not cats
  [OK] allergic to everything

[Suite] List the allergies
  [OK] no allergies
  [OK] just eggs
  [OK] just peanuts
  [OK] just strawberries
  [OK] eggs and peanuts
  [OK] more than eggs but not peanuts
  [OK] lots of stuff
  [OK] everything
  [OK] no allergen score parts
```


#### Completely separate suites
```
[Suite] Eggs allergy
  [OK] not allergic to anything
  [OK] allergic only to eggs
  [OK] allergic to eggs and something else
  [OK] allergic to something, but not eggs
  [OK] allergic to everything

[Suite] Peanuts allergy
  [OK] not allergic to anything
  [OK] allergic only to peanuts
  [OK] allergic to peanuts and something else
  [OK] allergic to something, but not peanuts
  [OK] allergic to everything

[Suite] Shellfish allergy
  [OK] not allergic to anything
  [OK] allergic only to shellfish
  [OK] allergic to shellfish and something else
  [OK] allergic to something, but not shellfish
  [OK] allergic to everything

[Suite] Strawberries allergy
  [OK] not allergic to anything
  [OK] allergic only to strawberries
  [OK] allergic to strawberries and something else
  [OK] allergic to something, but not strawberries
  [OK] allergic to everything

[Suite] Tomatoes allergy
  [OK] not allergic to anything
  [OK] allergic only to tomatoes
  [OK] allergic to tomatoes and something else
  [OK] allergic to something, but not tomatoes
  [OK] allergic to everything

[Suite] Chocolate allergy
  [OK] not allergic to anything
  [OK] allergic only to chocolate
  [OK] allergic to chocolate and something else
  [OK] allergic to something, but not chocolate
  [OK] allergic to everything

[Suite] Pollen allergy
  [OK] not allergic to anything
  [OK] allergic only to pollen
  [OK] allergic to pollen and something else
  [OK] allergic to something, but not pollen
  [OK] allergic to everything

[Suite] Cats allergy
  [OK] not allergic to anything
  [OK] allergic only to cats
  [OK] allergic to cats and something else
  [OK] allergic to something, but not cats
  [OK] allergic to everything

[Suite] List the allergies
  [OK] no allergies
  [OK] just eggs
  [OK] just peanuts
  [OK] just strawberries
  [OK] eggs and peanuts
  [OK] more than eggs but not peanuts
  [OK] lots of stuff
  [OK] everything
  [OK] no allergen score parts
```