### PR TITLE
Fix deprecation warnings and styleCheck warnings

### DIFF
--- a/exercises/isogram/example.nim
+++ b/exercises/isogram/example.nim
@@ -3,4 +3,4 @@ import
 
 proc isIsogram*(phrase: string): bool =
   let characters_lower = phrase.filterIt(it.isAlphaAscii()).mapIt(it.toLowerAscii)
-  len(toSet(characters_lower)) == len(characters_lower)
+  len(toHashSet(characters_lower)) == len(characters_lower)

--- a/exercises/isogram/example.nim
+++ b/exercises/isogram/example.nim
@@ -2,5 +2,5 @@ import
   sequtils, sets, strutils
 
 proc isIsogram*(phrase: string): bool =
-  let characters_lower = phrase.filterIt(it.isAlphaAscii()).mapIt(it.toLowerAscii)
-  len(toHashSet(characters_lower)) == len(characters_lower)
+  let charactersLower = phrase.filterIt(it.isAlphaAscii()).mapIt(it.toLowerAscii)
+  len(toHashSet(charactersLower)) == len(charactersLower)

--- a/exercises/pangram/example.nim
+++ b/exercises/pangram/example.nim
@@ -1,9 +1,9 @@
 import strutils
 
 const
-    ascii_lowercase = {'a'..'z'}
+    asciiLowercase = {'a'..'z'}
 
 proc isPangram*(sentence:string): bool =
-  for c in ascii_lowercase:
+  for c in asciiLowercase:
     if c notin sentence.toLowerAscii: return false
   return true

--- a/exercises/react/example.nim
+++ b/exercises/react/example.nim
@@ -6,7 +6,7 @@ type
     cells: seq[Cell]
     nextCellHandle: int16
   Cell* = ref object of RootObj
-    FValue: int
+    fValue: int
     id: int16
     reactor: Reactor
     consumers: seq[int16]
@@ -34,12 +34,12 @@ proc trigger(reactor: Reactor, start: Cell) =
     if id in needCheck:
       let
         cell = ComputeCell(reactor.cells[id])
-        vals = cell.producers.map(proc(p: Cell): int = p.FValue)
-        oldVal = cell.FValue
-      cell.FValue = cell.compute(vals)
-      if oldVal != cell.FValue:
+        vals = cell.producers.map(proc(p: Cell): int = p.fValue)
+        oldVal = cell.fValue
+      cell.fValue = cell.compute(vals)
+      if oldVal != cell.fValue:
         for callback in values(cell.callbacks):
-          callback(cell.FValue)
+          callback(cell.fValue)
         # TODO: Observers
         for consumerHandle in cell.consumers:
           incl(needCheck, consumerHandle)
@@ -56,13 +56,13 @@ proc createInput*(reactor: Reactor, value: int): InputCell =
   ## Create a new input cell.
   new(result)
   result.initCell(reactor)
-  result.FValue = value
+  result.fValue = value
 
-proc value*(cell: Cell): int = cell.FValue
+proc value*(cell: Cell): int = cell.fValue
 
 proc `value=`*(cell: InputCell, value: int) =
-  let oldVal = cell.FValue
-  cell.FValue = value
+  let oldVal = cell.fValue
+  cell.fValue = value
   if oldVal != value:
     cell.reactor.trigger(cell)
 
@@ -77,7 +77,7 @@ proc createCompute*(reactor: Reactor, inputs: seq[Cell], compute: ComputeFunc): 
   for idx, input in inputs:
     vals[idx] = input.value
     add(input.consumers, result.id)
-  result.FValue = compute(vals)
+  result.fValue = compute(vals)
 
 proc addCallback*(cell: ComputeCell, callback: CallbackFunc): CallbackHandle =
   add(cell.callbacks, cell.nextCallbackHandle, callback)

--- a/exercises/robot-name/robot_name_test.nim
+++ b/exercises/robot-name/robot_name_test.nim
@@ -40,7 +40,7 @@ suite "Robot Name":
 
   # test "all remaining robot names are distinct":
   #   const n = (26 * 26 * 1000) - 6 # The number of names not generated above.
-  #   var names = initSet[string](n.rightSize)
+  #   var names = initHashSet[string](n.rightSize)
   #   for i in 1 .. n:
   #     names.incl(makeRobot().name)
   #   check names.len == n

--- a/exercises/roman-numerals/example.nim
+++ b/exercises/roman-numerals/example.nim
@@ -3,7 +3,7 @@ type
   NumeralArray = array[13, Numeral]
 
 let
-  numeral_mapping: NumeralArray = [
+  numeralMapping: NumeralArray = [
     (1000, "M"),
     (900, "CM"),
     (500, "D"),
@@ -23,7 +23,7 @@ let
 proc roman*(number: int): string =
   result = ""
   var n = number
-  for numeral in numeral_mapping:
+  for numeral in numeralMapping:
     while n >= numeral.number:
       result = result & numeral.roman
       n = n - numeral.number

--- a/exercises/scale-generator/example.nim
+++ b/exercises/scale-generator/example.nim
@@ -3,7 +3,7 @@ import sets, strutils, tables
 const
   chromaticSharps = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
   chromaticFlats = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"]
-  flatKeys = ["F", "Bb", "Eb", "Ab", "Db", "Gb", "d", "g", "c", "f", "bb", "eb"].toSet
+  flatKeys = ["F", "Bb", "Eb", "Ab", "Db", "Gb", "d", "g", "c", "f", "bb", "eb"].toHashSet
   semitones = {'m': 1, 'M': 2, 'A': 3}.toTable
   defaultIntervals = "m".repeat(12)
 


### PR DESCRIPTION
This PR fixes warnings in the current (and upcoming) version of `check_exercises.nim`. It fixes:

- All deprecation warnings (see [recent Travis log](https://travis-ci.org/exercism/nim/builds/568761380#L1285) and [Nim `sets` docs](https://nim-lang.org/docs/sets.html#initSet)).
- All `styleCheck:hint` warnings.