### PR TITLE
Remove unused imports; Apply styleCheck suggestions

### DIFF
--- a/exercises/acronym/example.nim
+++ b/exercises/acronym/example.nim
@@ -1,5 +1,5 @@
 import re, sequtils, strutils
 
 proc abbreviate*(phrase: string): string =
-  let words = phrase.findall(re"[A-Z]+['a-z]*|['a-z]+")
+  let words = phrase.findAll(re"[A-Z]+['a-z]*|['a-z]+")
   words.mapIt(it[0].toUpperAscii).join

--- a/exercises/anagram/example.nim
+++ b/exercises/anagram/example.nim
@@ -5,7 +5,7 @@ type TAnagram = tuple
   word: string
   chars: seq[char]  # the lowercased and sorted chars of the word
 
-proc isAnagramTo(a, b: TAnagram): bool {.noSideEffect, procVar.} =
+proc isAnagramTo(a, b: TAnagram): bool {.noSideEffect.} =
   a.chars == b.chars and cmpIgnoreCase(a.word, b.word) != 0
 
 proc anagram(word: string): TAnagram =

--- a/exercises/binary/example.nim
+++ b/exercises/binary/example.nim
@@ -1,5 +1,4 @@
 from algorithm import reversed
-from sequtils import toSeq
 from strutils import allCharsInSet
 
 proc binary*(input: string): int {.raises: [ValueError]} =

--- a/exercises/leap/example.nim
+++ b/exercises/leap/example.nim
@@ -1,4 +1,4 @@
-proc isLeapYear*(y: int): bool {.noSideEffect, procvar.} =
+proc isLeapYear*(y: int): bool {.noSideEffect.} =
   ## Returns true if `y` is a leap year.
   ##
   ## .. code-block:: nim

--- a/exercises/matrix/example.nim
+++ b/exercises/matrix/example.nim
@@ -1,7 +1,7 @@
 import strutils
 
 func matrix(s: string): seq[seq[int]] =
-  for line in s.splitlines:
+  for line in s.splitLines:
     var row = newSeq[int]()
     for n in line.split:
       row &= n.parseInt

--- a/exercises/meetup/example.nim
+++ b/exercises/meetup/example.nim
@@ -4,7 +4,7 @@ type Schedule* = enum
   Teenth, First, Second, Third, Fourth, Last
 const startDay: array[Schedule, int] = [13, 1, 8, 15, 22, 1]
 
-proc meetup*(y: int, m: int, sched: Schedule, d: Weekday): string =
+proc meetup*(y: int, m: int, sched: Schedule, d: WeekDay): string =
   var dt = parse(&"{y}-{m}-{startDay[sched]}-12", "yyyy-M-d-hh", utc())
 
   if sched == Last:

--- a/exercises/nth-prime/example.nim
+++ b/exercises/nth-prime/example.nim
@@ -1,4 +1,4 @@
-import math, sequtils
+import math
 
 proc isPrime(n:int): bool =
   if n <= 1:


### PR DESCRIPTION
This PR addresses these small problems shown by `devel` Nim:
- Unused imports
- Newer `styleCheck` suggestions (overlooked in #209)

It also removes the (now-default) `procvar` pragmas. This change is relevant because one of them is capitalized as `procVar`, which produces a `styleCheck` hint.