### PR TITLE
Feature(resistor-color-trio): Implement exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -657,6 +657,18 @@
       ]
     },
     {
+      "slug": "resistor-color-trio",
+      "uuid": "6aa72d75-5c41-427a-a0fd-3253859e0f3e",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "arrays",
+        "enumerations",
+        "math"
+      ]
+    },
+    {
       "slug": "robot-name",
       "uuid": "5d2fa542-245a-4c5b-bfe1-bd667091c556",
       "core": false,

--- a/exercises/resistor-color-trio/README.md
+++ b/exercises/resistor-color-trio/README.md
@@ -1,0 +1,75 @@
+# Resistor Color Trio
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_. For this exercise, you need to know only three things about them:
+
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+  To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+- Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+  In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take 3 colors as input, and outputs the correct value, in ohms.
+  The color bands are encoded as follows:
+
+* Black: 0
+* Brown: 1
+* Red: 2
+* Orange: 3
+* Yellow: 4
+* Green: 5
+* Blue: 6
+* Violet: 7
+* Grey: 8
+* White: 9
+
+In `resistor-color duo` you decoded the first two colors. For instance: orange-orange got the main value `33`.
+The third color stands for how many zeros need to be added to the main value. The main value plus the zeros gives us a value in ohms.
+For the exercise it doesn't matter what ohms really are.
+For example:
+
+- orange-orange-black would be 33 and no zeros, which becomes 33 ohms.
+- orange-orange-red would be 33 and 2 zeros, which becomes 3300 ohms.
+- orange-orange-orange would be 33 and 3 zeros, which becomes 33000 ohms.
+
+(If Math is your thing, you may want to think of the zeros as exponents of 10. If Math is not your thing, go with the zeros. It really is the same thing, just in plain English instead of Math lingo.)
+
+This exercise is about translating the colors into a label:
+
+> "... ohms"
+
+So an input of `"orange", "orange", "black"` should return:
+
+> "33 ohms"
+
+When we get more than a thousand ohms, we say "kiloohms". That's similar to saying "kilometer" for 1000 meters, and "kilograms" for 1000 grams.
+So an input of `"orange", "orange", "orange"` should return:
+
+> "33 kiloohms"
+
+## Running the tests
+
+To compile and run the tests, just run the following in your exercise directory:
+```bash
+$ nim c -r resistor_color_trio_test.nim
+```
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/nim/resistor-color-trio` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Exercises Directory`.
+
+## Need help?
+
+These guides should help you,
+* [Installing Nim](https://exercism.io/tracks/nim/installation)
+* [Running the Tests](https://exercism.io/tracks/nim/tests)
+* [Learning Nim](https://exercism.io/tracks/nim/learning)
+* [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+
+
+## Source
+
+Maud de Vries, Erik Schierboom [https://github.com/exercism/problem-specifications/issues/1549](https://github.com/exercism/problem-specifications/issues/1549)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/resistor-color-trio/example.nim
+++ b/exercises/resistor-color-trio/example.nim
@@ -1,0 +1,20 @@
+import math
+
+type
+  ResistorColor* = enum
+    Black, Brown, Red, Orange, Yellow, Green, Blue, Violet, Grey, White
+  Resistor = array[3, ResistorColor]
+
+func ohms(a: Resistor): int =
+  (10 * a[0].ord + a[1].ord) * 10^(a[2].ord)
+
+func label*(a: Resistor): tuple[value: int, unit: string] =
+  result.value = ohms(a)
+  const units = ["ohms", "kiloohms", "megaohms", "gigaohms"]
+
+  for i in 0 .. units.high:
+    if result.value >= 1000:
+      result.value = result.value div 1000
+    else:
+      result.unit = units[i]
+      return

--- a/exercises/resistor-color-trio/resistor_color_trio_test.nim
+++ b/exercises/resistor-color-trio/resistor_color_trio_test.nim
@@ -1,0 +1,20 @@
+import unittest
+import resistor_color_trio
+
+# version 1.0.0
+
+suite "Resistor Color Trio":
+  test "orange and orange and black":
+    check label([Orange, Orange, Black]) == (33, "ohms")
+
+  test "blue and grey and brown":
+    check label([Blue, Grey, Brown]) == (680, "ohms")
+
+  test "red and black and red":
+    check label([Red, Black, Red]) == (2, "kiloohms")
+
+  test "green and brown and orange":
+    check label([Green, Brown, Orange]) == (51, "kiloohms")
+
+  test "yellow and violet and yellow":
+    check label([Yellow, Violet, Yellow]) == (470, "kiloohms")


### PR DESCRIPTION
### Problem specifications
[Exercise description](https://github.com/exercism/problem-specifications/blob/master/exercises/resistor-color-trio/description.md)
[Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/resistor-color-trio/canonical-data.json)


### Summary
- Implement the input type as an `array`, not a `seq`.
- Support only `tuple` (and not `object`) as the return type.
- `example.nim`: Support megaohms and gigaohms.
- `example.nim`: Omit creating a compile-time lookup.


### Other tracks
4 other tracks implement `resistor-color-trio`:
- [bash](https://www.github.com/exercism/bash/tree/master/exercises/resistor-color-trio)
- [c](https://www.github.com/exercism/c/tree/master/exercises/resistor-color-trio)
- [javascript](https://www.github.com/exercism/javascript/tree/master/exercises/resistor-color-trio)
- [ruby](https://www.github.com/exercism/ruby/tree/master/exercises/resistor-color-trio)


### Comments
#### Writing tests
There is the usual question about how to write tests for exercises that check more than one thing.

1) Check equality with a tuple:

```nim
suite "Resistor Color Trio":
  test "orange and orange and black":
    check label([Orange, Orange, Black]) == (33, "ohms")

  test "blue and grey and brown":
    check label([Blue, Grey, Brown]) == (680, "ohms")

  test "red and black and red":
    check label([Red, Black, Red]) == (2, "kiloohms")

  test "green and brown and orange":
    check label([Green, Brown, Orange]) == (51, "kiloohms")

  test "yellow and violet and yellow":
    check label([Yellow, Violet, Yellow]) == (470, "kiloohms")
```

2) Check the fields:

```nim
suite "Resistor Color Trio":
  test "orange and orange and black":
    let r = label([Orange, Orange, Black])
    check:
      r.value == 33
      r.unit == "ohms"

  test "blue and grey and brown":
    let r = label([Blue, Grey, Brown])
    check:
      r.value == 680
      r.unit == "ohms"

  test "red and black and red":
    let r = label([Red, Black, Red])
    check:
      r.value == 2
      r.unit == "kiloohms"

  test "green and brown and orange":
    let r = label([Green, Brown, Orange])
    check:
      r.value == 51
      r.unit == "kiloohms"

  test "yellow and violet and yellow":
    let r = label([Yellow, Violet, Yellow])
    check:
      r.value == 470
      r.unit == "kiloohms"
```

Advantages of the former:
- Shorter.
- Arguably more readable.
- Doesn't insist on a certain naming of the tuple fields (but does insist on their order).

Advantages of the latter:
- Supports a return type of `object`, rather than just `tuple`.
- Slightly better performance.

I picked the former here.


#### Compile-time lookup
It is easy to compute a lookup for all 1000 color combinations at compile-time. One simple implementation has the below diff to the PR's `example.nim`:

```diff
import math

type
  ResistorColor* = enum
    Black, Brown, Red, Orange, Yellow, Green, Blue, Violet, Grey, White
  Resistor = array[3, ResistorColor]
>   Label = tuple
>     value: int
>     unit: string

func ohms(a: Resistor): int =
  (10 * a[0].ord + a[1].ord) * 10^(a[2].ord)

< func label*(a: Resistor): tuple[value: int, unit: string] =
> func labelOne(a: Resistor): Label =
  result.value = ohms(a)
  const units = ["ohms", "kiloohms", "megaohms", "gigaohms"]

  for i in 0 .. units.high:
    if result.value >= 1000:
      result.value = result.value div 1000
    else:
      result.unit = units[i]
      return

> func generateLookup: array[1000, Label] =
>   var resistor: Resistor
>   var i = 0
>
>   for b2 in ResistorColor:
>     resistor[2] = b2
>     for b1 in ResistorColor:
>       resistor[1] = b1
>       for b0 in ResistorColor:
>         resistor[0] = b0
>         result[i] = labelOne(resistor)
>         inc i
>
> const lookup = generateLookup() # Compute all labels at compile-time.
>
> func label*(a: Resistor): Label =
>   let i = a[0].ord + (10 * a[1].ord) + (100 * a[2].ord)
>   result = lookup[i]
```