### PR TITLE
CI(Travis): Use Nim 1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 language: c
 
 env:
-  - NIM_VERSION="1.0.0"
+  - NIM_VERSION="1.0.2"
 
 install:
   - sh bin/travis-install.sh


### PR DESCRIPTION
This PR updates the Travis CI configuration to use the latest Nim release.

See [changelog](https://github.com/nim-lang/Nim/blob/devel/changelogs/changelog_1_0_2.md).