### PR TITLE
CI(Travis): Use Nim 1.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 language: c
 
 env:
-  - NIM_VERSION="1.0.2"
+  - NIM_VERSION="1.0.4"
 
 install:
   - sh bin/travis-install.sh


### PR DESCRIPTION
This PR updates the Travis CI configuration to use the latest Nim release.

See https://nim-lang.org/blog/2019/11/26/version-104-released.html