### PR TITLE
Remove unused import in Robot Name test file

### DIFF
--- a/exercises/robot-name/robot_name_test.nim
+++ b/exercises/robot-name/robot_name_test.nim
@@ -1,4 +1,4 @@
-import unittest, sets
+import unittest
 import robot_name
 
 func isValidRobotName(s: string): bool =


### PR DESCRIPTION
I was looking at the output of the build on Travis Ci, and seeing that there is an unused import in the robot name test file. This PR removes "sets" as it seems not to be used in the file any more.

![nim - Travis CI 2019-11-28 16-05-43](https://user-images.githubusercontent.com/598958/69831775-f187ec80-11f8-11ea-8857-198f764a3e4c.png)
