### PR TITLE
robot-name: Fix warning; Enable bonus test for CI

### DIFF
--- a/_test/check_exercises.nim
+++ b/_test/check_exercises.nim
@@ -1,4 +1,4 @@
-import critbits, os, osproc, parseopt, streams, strutils, terminal
+import critbits, os, osproc, parseopt, streams, strscans, strutils, terminal
 
 ## This file is for testing the Nim track of exercism.io.
 ##
@@ -140,6 +140,10 @@ proc wrapTest(file: string, slug: string): string =
       # If there are multiple suites, keep the suite names as comments only.
       if numSuites > 1:
         result &= "    # " & line[7 .. ^3] & "\n"
+    # Enable bonus tests that are disabled by default.
+    elif line.scanf("$sconst runBonusTest"): # Also support `runBonusTests`.
+      let indent = if inSuite: "  " else: ""
+      result &= indent & line.split('=')[0] & "= true\n"
     elif inSuite:
       result &= "  " & line & "\n"
     else:

--- a/_test/check_exercises.nim
+++ b/_test/check_exercises.nim
@@ -179,9 +179,12 @@ proc prepareTests(slugs: Slugs) =
   writeFile(allTestsPath, allTests)
 
 proc quietRun: int =
-  ## Runs the previously prepared tests, but only prints failing tests and a
-  ## short summary. It also hides compiler messages that are less useful or
-  ## relate to intended behavior.
+  ## Runs the previously prepared tests, but only prints:
+  ## - The more useful compiler output (minimum: any `CC` messages and a
+  ##   `SuccessX` hint).
+  ## - Failed tests.
+  ## - The number of passing exercises.
+  ## - The number of failing exercises and their names.
   ##
   ## Returns the exit code, which is `0` if all tests pass and `1` otherwise.
   result = -1
@@ -193,17 +196,6 @@ proc quietRun: int =
 
   const suiteStr = "[Suite] "
   const failedStr = "  [FAILED]"
-
-  func isExpectedCompilerMessage(s: string): bool =
-    ## Returns `true` if `s` represents an expected compiler message that can
-    ## be ignored in quiet mode.
-    const ignore = {
-      # `robot-name`: the `sets` import is used for a commented-out bonus test.
-      "test_robot_name.nim": "imported and not used: 'sets'"
-    }
-    for (file, message) in ignore:
-      if s.contains(file) and s.contains(message):
-        return true
 
   var
     p = startProcess("nim", args = args, options = {poStdErrToStdOut, poUsePath})
@@ -246,8 +238,6 @@ proc quietRun: int =
         let testDesc = line[failedStr.len .. ^1]
         stdout.styledWrite(fgRed, styleBright, failedStr)
         stdout.writeLine(testDesc)
-      elif line.isExpectedCompilerMessage():
-        continue
       else:
         stdout.writeLine(line)
     else:

--- a/exercises/robot-name/example.nim
+++ b/exercises/robot-name/example.nim
@@ -1,33 +1,44 @@
-import intsets, random, strutils
+import random
 
-type Robot = tuple[name: string]
-const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+type
+  Name = array[5, char]
+  Robot = object
+    name*: Name
+
 const numNames = 26 * 26 * 10 * 10 * 10
-var nums = initIntSet()
-nums.incl(numNames)
 randomize()
 
-func createLeadingZerosLookup: array[1000, string] =
-  for i in 0 .. result.high:
-    result[i] = i.`$`.align(3, '0')
+proc shuffledNames: seq[Name] =
+  result = newSeq[Name](numNames)
+  var name: Name
+  var i = 0
 
-const zeroPad = createLeadingZerosLookup()
+  for a in 'A'..'Z':
+    name[0] = a
+    for b in 'A'..'Z':
+      name[1] = b
+      for c in '0'..'9':
+        name[2] = c
+        for d in '0'..'9':
+          name[3] = d
+          for e in '0'..'9':
+            name[4] = e
+            result[i] = name
+            inc(i)
 
-func toName(n: Natural): string =
-  let b = n div 1000
-  let a = b div 26
-  result = alphabet[a mod 26] & alphabet[b mod 26] & zeroPad[n mod 1000]
+  shuffle(result)
 
-proc getUnusedName(s: var IntSet): string =
-  var i = numNames
-  # The below is faster than shuffling when generating a small number of names.
-  while i in s:
-    i = rand(numNames)
-  s.incl(i)
-  result = toName(i)
+let names = shuffledNames()
+var i = 0
 
-proc makeRobot*: Robot =
-  result.name = getUnusedName(nums)
+proc getUnusedName: Name {.inline.} =
+  # The tests do not currently specify the expected behavior on name exhaustion.
+  # The below checks that a "wraparound" implementation is supported.
+  result = names[i]
+  i = if i > names.high: 0 else: i + 1
 
-proc reset*(r: var Robot) =
-  r.name = getUnusedName(nums)
+proc makeRobot*: Robot {.inline.} =
+  result.name = getUnusedName()
+
+proc reset*(r: var Robot) {.inline.} =
+  r.name = getUnusedName()

--- a/exercises/robot-name/robot_name_test.nim
+++ b/exercises/robot-name/robot_name_test.nim
@@ -1,5 +1,9 @@
-import unittest, sets
+import unittest
 import robot_name
+
+const runBonusTest = false
+when runBonusTest:
+  import sets
 
 func isValidRobotName(s: string): bool =
   ## Returns true if `s` is two uppercase letters followed by three digits.
@@ -36,11 +40,12 @@ suite "Robot Name":
       isValidRobotName(nameAfter)
 
   # Bonus
-  # This test is optional. Uncomment the lines below to enable it.
+  # The below test is optional. Change `runBonusTest` to `true` to run it.
 
-  # test "all remaining robot names are distinct":
-  #   const n = (26 * 26 * 1000) - 6 # The number of names not generated above.
-  #   var names = initHashSet[string](n.rightSize)
-  #   for i in 1 .. n:
-  #     names.incl(makeRobot().name)
-  #   check names.len == n
+  when runBonusTest:
+    test "all remaining robot names are distinct":
+      const n = (26 * 26 * 1000) - 6 # The number of names not generated above.
+      var names = initHashSet[string](n.rightSize)
+      for i in 1 .. n:
+        names.incl(makeRobot().name)
+      check names.len == n

--- a/exercises/robot-name/robot_name_test.nim
+++ b/exercises/robot-name/robot_name_test.nim
@@ -1,18 +1,21 @@
 import unittest
 import robot_name
 
-const runBonusTest = false
-when runBonusTest:
-  import sets
+# You can implement the robot name as a `string` or an `array[5, char]`.
+type
+  RobotName = string | array[5, char]
 
-func isValidRobotName(s: string): bool =
-  ## Returns true if `s` is two uppercase letters followed by three digits.
-  s.len == 5 and
-    s[0] in {'A'..'Z'} and
-    s[1] in {'A'..'Z'} and
-    s[2] in {'0'..'9'} and
-    s[3] in {'0'..'9'} and
-    s[4] in {'0'..'9'}
+func isValidRobotName(name: RobotName): bool =
+  ## Returns true if `name` is two uppercase letters followed by three digits.
+  when name is string:
+    if name.len != 5:
+      return false
+  result =
+    name[0] in {'A'..'Z'} and
+    name[1] in {'A'..'Z'} and
+    name[2] in {'0'..'9'} and
+    name[3] in {'0'..'9'} and
+    name[4] in {'0'..'9'}
 
 suite "Robot Name":
   test "robot has a valid name":
@@ -39,13 +42,35 @@ suite "Robot Name":
       nameBefore != nameAfter
       isValidRobotName(nameAfter)
 
-  # Bonus
   # The below test is optional. Change `runBonusTest` to `true` to run it.
+  const runBonusTest = false
 
   when runBonusTest:
-    test "all remaining robot names are distinct":
-      const n = (26 * 26 * 1000) - 6 # The number of names not generated above.
-      var names = initHashSet[string](n.rightSize)
-      for i in 1 .. n:
-        names.incl(makeRobot().name)
-      check names.len == n
+    func toInt(name: RobotName): int =
+      ## Returns a unique integer for each valid robot name.
+      (name[0].ord - 'A'.ord) * 26000 +
+      (name[1].ord - 'A'.ord) * 1000 +
+      (name[2].ord - '0'.ord) * 100 +
+      (name[3].ord - '0'.ord) * 10 +
+      (name[4].ord - '0'.ord)
+
+    test "all remaining robot names are valid and distinct":
+      const totalNames = 26 * 26 * 1000
+      var nums = newSeq[bool](totalNames)
+      const n = totalNames - 6 # The number of names not generated above.
+      var countDuplicate = 0
+      var countInvalid = 0
+
+      for _ in 1 .. n:
+        let name = makeRobot().name
+        if isValidRobotName(name):
+          let i = toInt(name)
+          if nums[i]:
+            inc(countDuplicate)
+          else:
+            nums[i] = true
+        else:
+          inc(countInvalid)
+      check:
+        countDuplicate == 0
+        countInvalid == 0


### PR DESCRIPTION
This PR:
- Removes the "unused import" warning that appeared in CI logs.
- Enables the `robot-name` bonus test during CI.
- Better optimizes the `robot-name` example implementation and its bonus test.

See the commit messages for more details.