### PR TITLE
CI: Update `fetch-configlet` script

### DIFF
--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -1,32 +1,44 @@
 #!/bin/bash
 
-LATEST=https://github.com/exercism/configlet/releases/latest
+set -eo pipefail
 
-OS=$(
-case $(uname) in
-    (Darwin*)
-        echo "mac";;
-    (Linux*)
-        echo "linux";;
-    (Windows*)
-        echo "windows";;
-    (*)
-        echo "linux";;
-esac)
+readonly RELEASES='https://github.com/exercism/configlet/releases'
 
-ARCH=$(
-case $(uname -m) in
-    (*64*)
-        echo 64bit;;
-    (*686*)
-        echo 32bit;;
-    (*386*)
-        echo 32bit;;
-    (*)
-        echo 64bit;;
-esac)
+get_version () {
+    curl --silent --head ${RELEASES}/latest  |
+        awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r'
+}
 
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
-URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
+case "$(uname)" in
+    (Darwin*)   OS='mac'     ;;
+    (Linux*)    OS='linux'   ;;
+    (Windows*)  OS='windows' ;;
+    (MINGW*)    OS='windows' ;;
+    (MSYS_NT-*) OS='windows' ;;
+    (*)         OS='linux'   ;;
+esac
 
-curl -s --location $URL | tar xz -C bin/
+case "$OS" in
+    (windows*) EXT='zip' ;;
+    (*)        EXT='tgz' ;;
+esac
+
+case "$(uname -m)" in
+    (*64*)  ARCH='64bit' ;;
+    (*686*) ARCH='32bit' ;;
+    (*386*) ARCH='32bit' ;;
+    (*)     ARCH='64bit' ;;
+esac
+
+
+VERSION="$(get_version)"
+URL="${RELEASES}/download/${VERSION}/configlet-${OS}-${ARCH}.${EXT}"
+
+case "$EXT" in
+    (*zip)
+        curl -s --location "$URL" -o bin/latest-configlet.zip
+        unzip bin/latest-configlet.zip -d bin/
+        rm bin/latest-configlet.zip
+        ;;
+    (*) curl -s --location "$URL" | tar xz -C bin/ ;;
+esac


### PR DESCRIPTION
This PR makes the `fetch-configlet` script more robust and idiomatic.

Upstream: https://github.com/exercism/configlet/blob/master/scripts/fetch-configlet