### PR TITLE
Refactor(queen-attack): Reimplement exercise

### DIFF
--- a/exercises/queen-attack/example.nim
+++ b/exercises/queen-attack/example.nim
@@ -1,32 +1,35 @@
-proc isValid(white, black: tuple[rank, file: int]): bool =
-  white.rank < 8 and white.rank >= 0 and white.file < 8 and white.file >= 0 and
-    black.rank < 8 and black.rank >= 0 and black.file < 8 and black.file >= 0
+type
+  Queen* = object
+    row*: range[0..7]
+    col*: range[0..7]
 
-proc validate(white, black: tuple[rank, file: int]): void =
-  if not isValid(white, black) or white == black:
-    raise newException(ValueError, "Invalid positions")
+func initQueen*(row, col: int): Queen =
+  if row in {0..7} and col in {0..7}:
+    result = Queen(row: row, col: col)
+  else:
+    raise newException(ValueError, "Invalid position")
 
-proc board*(white, black: tuple[rank, file: int]): seq[string] =
-  validate(white, black)
+func raiseIfSame(white, black: Queen) =
+  if white == black:
+    raise newException(ValueError, "The queens cannot have the same position")
 
-  var board: seq[string] = @[]
+func canAttack*(white, black: Queen): bool =
+  raiseIfSame(white, black)
+  let rowDiff = abs(white.row - black.row)
+  let colDiff = abs(white.col - black.col)
+  result = (rowDiff == colDiff) or (rowDiff * colDiff == 0)
 
-  for rank in 0..7:
-    board.add("")
-    for file in 0..7:
-      if white == (rank, file):
-        board[rank] &= 'W'
-      elif black == (rank, file):
-        board[rank] &= 'B'
-      else:
-        board[rank] &= '_'
-
-  board
-
-proc canAttack*(white, black: tuple[rank, file: int]): bool =
-  validate(white, black)
-
-  let rankDiff = abs(white.rank - black.rank)
-  let fileDiff = abs(white.file - black.file)
-
-  rankDiff == fileDiff or rankDiff * fileDiff == 0
+func board*(white, black: Queen): string =
+  raiseIfSame(white, black)
+  result = """
+________
+________
+________
+________
+________
+________
+________
+________
+"""
+  result[white.row * 9 + white.col] = 'W'
+  result[black.row * 9 + black.col] = 'B'

--- a/exercises/queen-attack/queen_attack_test.nim
+++ b/exercises/queen-attack/queen_attack_test.nim
@@ -4,92 +4,98 @@ import queen_attack
 # version 2.3.0
 
 suite "Queen Attack":
-  # Raise an error for invalid positions
-  test "invalid row: too low":
-    expect(ValueError): discard canAttack((-2, 2), (0, 0))
-    expect(ValueError): discard canAttack((0, 0), (-2, 2))
+  # Test creation of Queens with valid and invalid positions
+  test "queen with a valid position":
+    check:
+      initQueen(2, 2) == Queen(row: 2, col: 2)
 
-  test "invalid row: too high":
-    expect(ValueError): discard canAttack((8, 4), (0, 0))
-    expect(ValueError): discard canAttack((0, 0), (8, 4))
+  test "queen must have positive row":
+    expect(ValueError):
+      discard initQueen(-2, 2)
 
-  test "invalid column: too low":
-    expect(ValueError): discard canAttack((2, -2), (0, 0))
-    expect(ValueError): discard canAttack((0, 0), (2, -2))
+  test "queen must have row on board":
+    expect(ValueError):
+      discard initQueen(8, 4)
 
-  test "invalid column: too high":
-    expect(ValueError): discard canAttack((4, 8), (0, 0))
-    expect(ValueError): discard canAttack((0, 0), (4, 8))
+  test "queen must have positive column":
+    expect(ValueError):
+      discard initQueen(2, -2)
 
+  test "queen must have column on board":
+    expect(ValueError):
+      discard initQueen(4, 8)
 
   # Test the ability of one queen to attack another
   test "cannot attack":
-    check canAttack((2, 4), (6, 6)) == false
+    let whiteQueen = initQueen(2, 4)
+    let blackQueen = initQueen(6, 6)
+    check canAttack(whiteQueen, blackQueen) == false
 
   test "can attack on same row":
-    check canAttack((2, 4), (2, 6)) == true
+    let whiteQueen = initQueen(2, 4)
+    let blackQueen = initQueen(2, 6)
+    check canAttack(whiteQueen, blackQueen) == true
 
   test "can attack on same column":
-    check canAttack((4, 5), (2, 5)) == true
+    let whiteQueen = initQueen(4, 5)
+    let blackQueen = initQueen(2, 5)
+    check canAttack(whiteQueen, blackQueen) == true
 
   test "can attack on first diagonal":
-    check canAttack((2, 2), (0, 4)) == true
+    let whiteQueen = initQueen(2, 2)
+    let blackQueen = initQueen(0, 4)
+    check canAttack(whiteQueen, blackQueen) == true
 
   test "can attack on second diagonal":
-    check canAttack((2, 2), (3, 1)) == true
+    let whiteQueen = initQueen(2, 2)
+    let blackQueen = initQueen(3, 1)
+    check canAttack(whiteQueen, blackQueen) == true
 
   test "can attack on third diagonal":
-    check canAttack((2, 2), (1, 1)) == true
+    let whiteQueen = initQueen(2, 2)
+    let blackQueen = initQueen(1, 1)
+    check canAttack(whiteQueen, blackQueen) == true
 
   test "can attack on fourth diagonal":
-    check canAttack((1, 7), (0, 6)) == true
-
+    let whiteQueen = initQueen(1, 7)
+    let blackQueen = initQueen(0, 6)
+    check canAttack(whiteQueen, blackQueen) == true
 
   # Bonus: graphical board representation
   test "represent a board graphically #1":
-    check board((2, 3), (5, 6)) == @["________",
-                                     "________",
-                                     "___W____",
-                                     "________",
-                                     "________",
-                                     "______B_",
-                                     "________",
-                                     "________"]
+    let whiteQueen = initQueen(2, 3)
+    let blackQueen = initQueen(5, 6)
+    check board(whiteQueen, blackQueen) == "________\n" &
+                                           "________\n" &
+                                           "___W____\n" &
+                                           "________\n" &
+                                           "________\n" &
+                                           "______B_\n" &
+                                           "________\n" &
+                                           "________\n"
 
   test "represent a board graphically #2":
-    check board((0, 6), (1, 7)) == @["______W_",
-                                     "_______B",
-                                     "________",
-                                     "________",
-                                     "________",
-                                     "________",
-                                     "________",
-                                     "________"]
-
-
-  # Bonus: raise an error for invalid positions
-  test "invalid row: too low (board)":
-    expect(ValueError): discard board((-2, 2), (0, 0))
-    expect(ValueError): discard board((0, 0), (-2, 2))
-
-  test "invalid row: too high (board)":
-    expect(ValueError): discard board((8, 4), (0, 0))
-    expect(ValueError): discard board((0, 0), (8, 4))
-
-  test "invalid column: too low (board)":
-    expect(ValueError): discard board((2, -2), (0, 0))
-    expect(ValueError): discard board((0, 0), (2, -2))
-
-  test "invalid column: too high (board)":
-    expect(ValueError): discard board((4, 8), (0, 0))
-    expect(ValueError): discard board((0, 0), (4, 8))
+    let whiteQueen = initQueen(0, 6)
+    let blackQueen = initQueen(1, 7)
+    check board(whiteQueen, blackQueen) == "______W_\n" &
+                                           "_______B\n" &
+                                           "________\n" &
+                                           "________\n" &
+                                           "________\n" &
+                                           "________\n" &
+                                           "________\n" &
+                                           "________\n"
 
 
   # Bonus: raise an error if queens occupy the same position
   test "queens cannot have the same position (canAttack)":
+    let whiteQueen = initQueen(2, 2)
+    let blackQueen = initQueen(2, 2)
     expect(ValueError):
-      discard canAttack((2, 2), (2, 2))
+      discard canAttack(whiteQueen, blackQueen)
 
   test "queens cannot have the same position (board)":
+    let whiteQueen = initQueen(2, 2)
+    let blackQueen = initQueen(2, 2)
     expect(ValueError):
-      discard board((2, 2), (2, 2))
+      discard board(whiteQueen, blackQueen)


### PR DESCRIPTION
Previously, we did not implement the first test case of the canonical data:

```json
{
  "uuid": "3ac4f735-d36c-44c4-a3e2-316f79704203",
  "description": "queen with a valid position",
  "property": "create",
  "input": {
    "queen": {
      "position": {
        "row": 2,
        "column": 2
      }
    }
  },
  "expected": 0
},
```

This PR:
- Reimplements the exercise from the canonical data so that we can add
  the missing test case, which will allow us to set all the tests to
  `true` in `queen-attack/.meta/tests.toml`.
- Changes the `canAttack` and `board` procs to take a `Queen` object as
  their argument, rather than a pair of (row, col) tuples. This is more
  in the spirit of the canonical data. It also allows us to remove the
  bonus checking of invalid positions in `board`.
- Changes the `board` proc to return a `string` rather than a `seq`,
  making it consistent with exercises like `diamond` and `twelve-days`.
- Makes the Nim code a bit more idiomatic.