### PR TITLE
Refactor(perfect-numbers): Prefer "positive integers"

### DIFF
--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -1,9 +1,9 @@
 # Perfect Numbers
 
 Determine if a number is perfect, abundant, or deficient based on
-Nicomachus' (60 - 120 CE) classification scheme for natural numbers.
+Nicomachus' (60 - 120 CE) classification scheme for positive integers.
 
-The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) devised a classification scheme for natural numbers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum](https://en.wikipedia.org/wiki/Aliquot_sum). The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
+The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) devised a classification scheme for positive integers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum](https://en.wikipedia.org/wiki/Aliquot_sum). The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
 
 - **Perfect**: aliquot sum = number
   - 6 is a perfect number because (1 + 2 + 3) = 6

--- a/exercises/perfect-numbers/perfect_numbers_test.nim
+++ b/exercises/perfect-numbers/perfect_numbers_test.nim
@@ -37,10 +37,10 @@ suite "Perfect Numbers":
   test "edge case (no factors other than itself) is classified correctly":
     check classify(1) == Deficient
 
-  test "zero is rejected (not a positive number)":
+  test "zero is rejected (as it is not a positive integer)":
     expect ValueError:
       discard classify(0)
 
-  test "negative integer is rejected (not a positive number)":
+  test "negative integer is rejected (as it is not a positive integer)":
     expect ValueError:
       discard classify(-1)


### PR DESCRIPTION
I already made the substitution "natural" -> "positive" when I implemented this exercise, to avoid potential confusion with the
`Natural` type in `system` (see [system.Natural](https://nim-lang.github.io/Nim/system.html#Natural)), which is defined as:
```Nim
    Natural = range[0 .. high(int)]
```



Upstream: https://github.com/exercism/problem-specifications/commit/fcbc25191f44