### PR TITLE
Fix: Remove canonical data version from test files

### DIFF
--- a/exercises/acronym/acronym_test.nim
+++ b/exercises/acronym/acronym_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import acronym
 
-# version 1.7.0
-
 suite "Acronym":
   test "basic":
     check abbreviate("Portable Network Graphics") == "PNG"

--- a/exercises/all-your-base/all_your_base_test.nim
+++ b/exercises/all-your-base/all_your_base_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import all_your_base
 
-# version 2.3.0
-
 suite "All Your Base":
   test "single bit one to decimal":
     let inputDigits = [1]

--- a/exercises/allergies/allergies_test.nim
+++ b/exercises/allergies/allergies_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import allergies
 
-# version 2.0.0
-
 suite "Eggs allergy":
   test "not allergic to anything":
     let allergies = Allergies(score: 0)

--- a/exercises/anagram/anagram_test.nim
+++ b/exercises/anagram/anagram_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import anagram
 
-# version 1.5.0
-
 suite "Anagram":
   test "no matches":
     const word = "diaper"

--- a/exercises/armstrong-numbers/armstrong_numbers_test.nim
+++ b/exercises/armstrong-numbers/armstrong_numbers_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import armstrong_numbers
 
-# version 1.1.0
-
 suite "Armstrong Numbers":
   test "zero is an Armstrong number":
     check isArmstrongNumber(0) == true

--- a/exercises/atbash-cipher/atbash_cipher_test.nim
+++ b/exercises/atbash-cipher/atbash_cipher_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import atbash_cipher
 
-# version 1.2.0
-
 # The tests are divided into two groups:
 # Encoding from English to atbash cipher
 # Decoding from atbash cipher to all-lowercase-mashed-together English

--- a/exercises/binary/binary_test.nim
+++ b/exercises/binary/binary_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import binary
 
-# version 1.1.0
-
 suite "Binary":
   test "binary 0 is decimal 0":
     check binary("0") == 0

--- a/exercises/bob/bob_test.nim
+++ b/exercises/bob/bob_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import bob
 
-# version 1.6.0
-
 suite "Bob":
   test "stating something":
     check hey("Tom-ay-to, tom-aaaah-to.") == "Whatever."

--- a/exercises/clock/clock_test.nim
+++ b/exercises/clock/clock_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import clock
 
-# version 2.4.0
-
 suite "Create a new clock with an initial time":
   test "on the hour":
     check create((8, 0)).toStr == "08:00"

--- a/exercises/collatz-conjecture/collatz_conjecture_test.nim
+++ b/exercises/collatz-conjecture/collatz_conjecture_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import collatz_conjecture
 
-# version 1.2.1
-
 suite "Collatz Conjecture":
   test "zero steps for one":
     check steps(1) == 0

--- a/exercises/crypto-square/crypto_square_test.nim
+++ b/exercises/crypto-square/crypto_square_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import crypto_square
 
-# version 3.2.0
-
 suite "Crypto Square":
   test "empty plaintext results in an empty ciphertext":
     check encrypt("") == ""

--- a/exercises/darts/darts_test.nim
+++ b/exercises/darts/darts_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import darts
 
-# version 2.2.0
-
 suite "Darts":
   test "missed target":
     check score((-9.0, 9.0)) == 0

--- a/exercises/diamond/diamond_test.nim
+++ b/exercises/diamond/diamond_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import diamond
 
-# version 1.1.0
-
 suite "Diamond":
   test "degenerate case with a single 'A' row":
     const expected = "A\n"

--- a/exercises/difference-of-squares/difference_of_squares_test.nim
+++ b/exercises/difference-of-squares/difference_of_squares_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import difference_of_squares
 
-# version 1.2.0
-
 suite "Difference of Squares":
   test "square of sum 1":
     check squareOfSum(1) == 1

--- a/exercises/diffie-hellman/diffie_hellman_test.nim
+++ b/exercises/diffie-hellman/diffie_hellman_test.nim
@@ -1,8 +1,6 @@
 import unittest, intsets
 import diffie_hellman
 
-# version 1.0.0
-
 suite "Diffie Hellman":
   test "private key is greater than 1 and less than p":
     const primes = [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]

--- a/exercises/etl/etl_test.nim
+++ b/exercises/etl/etl_test.nim
@@ -1,8 +1,6 @@
 import unittest, tables
 import etl
 
-# version 2.0.1
-
 suite "ETL":
   test "single letter":
     const input = {

--- a/exercises/gigasecond/gigasecond_test.nim
+++ b/exercises/gigasecond/gigasecond_test.nim
@@ -1,8 +1,6 @@
 import unittest, times
 import gigasecond
 
-# version 2.0.0
-
 suite "Gigasecond":
   test "date only specification of time":
     let moment   = initDateTime(25, mApr, 2011, 0, 0, 0, utc())

--- a/exercises/grade-school/grade_school_test.nim
+++ b/exercises/grade-school/grade_school_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import grade_school
 
-# version 1.0.1
-
 # Given students' names along with the grade that they are in,
 # create a roster for the school.
 

--- a/exercises/grains/grains_test.nim
+++ b/exercises/grains/grains_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import grains
 
-# version 1.2.0
-
 suite "Grains":
   test "grains on square 1":
     check onSquare(1) == 1

--- a/exercises/hamming/hamming_test.nim
+++ b/exercises/hamming/hamming_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import hamming
 
-# version 2.3.0
-
 suite "Hamming":
   test "empty strands":
     check distance("", "") == 0

--- a/exercises/hello-world/hello_world_test.nim
+++ b/exercises/hello-world/hello_world_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import hello_world
 
-# version 1.1.0
-
 suite "Hello World":
   test "say hi!":
     check hello() == "Hello, World!"

--- a/exercises/high-scores/high_scores_test.nim
+++ b/exercises/high-scores/high_scores_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import high_scores
 
-# version 4.0.0
-
 suite "High Scores":
   test "latest score":
     check latest(@[100, 0, 90, 30]) == 30

--- a/exercises/isbn-verifier/isbn_verifier_test.nim
+++ b/exercises/isbn-verifier/isbn_verifier_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import isbn_verifier
 
-# version 2.7.0
-
 suite "ISBN Verifier":
   test "valid ISBN":
     check isValid("3-598-21508-8") == true

--- a/exercises/isogram/isogram_test.nim
+++ b/exercises/isogram/isogram_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import isogram
 
-# version 1.7.0
-
 suite "Isogram":
   test "empty string":
     check isIsogram("") == true

--- a/exercises/kindergarten-garden/kindergarten_garden_test.nim
+++ b/exercises/kindergarten-garden/kindergarten_garden_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import kindergarten_garden
 
-# version 1.1.1
-
 suite "Kindergarten Garden":
   test "partial garden: garden with single student":
     const garden = "RC\n" &

--- a/exercises/largest-series-product/largest_series_product_test.nim
+++ b/exercises/largest-series-product/largest_series_product_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import largest_series_product
 
-# version 1.2.0
-
 suite "Largest Series Product":
   test "finds the largest product if span equals length":
     check largestProduct("29", 2) == 18

--- a/exercises/leap/leap_test.nim
+++ b/exercises/leap/leap_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import leap
 
-# version 1.6.0
-
 suite "Leap":
   test "year not divisible by 4 in common year":
     check isLeapYear(2015) == false

--- a/exercises/luhn/luhn_test.nim
+++ b/exercises/luhn/luhn_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import luhn
 
-# version 1.7.0
-
 suite "Luhn":
   test "single digit strings can not be valid":
     check isValid("1") == false

--- a/exercises/matching-brackets/matching_brackets_test.nim
+++ b/exercises/matching-brackets/matching_brackets_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import matching_brackets
 
-# version 2.0.0
-
 suite "Matching Brackets":
   test "paired square brackets":
     check isPaired("[]") == true

--- a/exercises/matrix/matrix_test.nim
+++ b/exercises/matrix/matrix_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import matrix
 
-# version 1.3.0
-
 suite "Matrix":
   test "extract row from one number matrix":
     check row("1", 1) == @[1]

--- a/exercises/meetup/meetup_test.nim
+++ b/exercises/meetup/meetup_test.nim
@@ -1,8 +1,6 @@
 import unittest, times
 import meetup
 
-# version 1.1.0
-
 suite "Meetup":
   test "monteenth of May 2013":
     check meetup(2013, 5, Teenth, dMon) == "2013-05-13"

--- a/exercises/nth-prime/nth_prime_test.nim
+++ b/exercises/nth-prime/nth_prime_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import nth_prime
 
-# version 2.1.0
-
 suite "Nth Prime":
   test "first prime":
     check prime(1) == 2

--- a/exercises/nucleotide-count/nucleotide_count_test.nim
+++ b/exercises/nucleotide-count/nucleotide_count_test.nim
@@ -1,8 +1,6 @@
 import unittest, tables
 import nucleotide_count
 
-# version 1.3.0
-
 suite "Nucleotide Count":
   test "empty strand":
     let counts = countDna("")

--- a/exercises/pangram/pangram_test.nim
+++ b/exercises/pangram/pangram_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import pangram
 
-# version 2.0.0
-
 suite "Pangram":
   test "empty sentence":
     check isPangram("") == false

--- a/exercises/pascals-triangle/pascals_triangle_test.nim
+++ b/exercises/pascals-triangle/pascals_triangle_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import pascals_triangle
 
-# version 1.5.0
-
 suite "Pascal's Triangle":
   test "zero rows":
     check pascal(0).len == 0

--- a/exercises/perfect-numbers/perfect_numbers_test.nim
+++ b/exercises/perfect-numbers/perfect_numbers_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import perfect_numbers
 
-# version 1.1.0
-
 suite "Perfect Numbers":
   test "smallest perfect number is classified correctly":
     check classify(6) == Perfect

--- a/exercises/phone-number/phone_number_test.nim
+++ b/exercises/phone-number/phone_number_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import phone_number
 
-# version 1.7.0
-
 suite "Phone Number":
   test "cleans the number":
     check clean("(223) 456-7890") == "2234567890"

--- a/exercises/prime-factors/prime_factors_test.nim
+++ b/exercises/prime-factors/prime_factors_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import prime_factors
 
-# version 1.1.0
-
 suite "Prime Factors":
   test "no factors":
     check primeFactors(1).len == 0

--- a/exercises/protein-translation/protein_translation_test.nim
+++ b/exercises/protein-translation/protein_translation_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import protein_translation
 
-# version 1.1.1
-
 suite "Protein Translation":
   test "identifies Methionine codon":
     check translate("AUG") == @["Methionine"]

--- a/exercises/proverb/proverb_test.nim
+++ b/exercises/proverb/proverb_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import proverb
 
-# version 1.1.0
-
 suite "Proverb":
   test "zero pieces":
     const words: seq[string] = @[]

--- a/exercises/queen-attack/queen_attack_test.nim
+++ b/exercises/queen-attack/queen_attack_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import queen_attack
 
-# version 2.3.0
-
 suite "Queen Attack":
   # Test creation of Queens with valid and invalid positions
   test "queen with a valid position":

--- a/exercises/raindrops/raindrops_test.nim
+++ b/exercises/raindrops/raindrops_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import raindrops
 
-# version 1.1.0
-
 suite "Raindrops":
   test "the sound for 1 is 1":
     check convert(1) == "1"

--- a/exercises/resistor-color-duo/resistor_color_duo_test.nim
+++ b/exercises/resistor-color-duo/resistor_color_duo_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import resistor_color_duo
 
-# version 2.1.0
-
 suite "Resistor Color Duo":
   test "brown and black":
     check value([Brown, Black]) == 10

--- a/exercises/resistor-color-trio/resistor_color_trio_test.nim
+++ b/exercises/resistor-color-trio/resistor_color_trio_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import resistor_color_trio
 
-# version 1.0.0
-
 suite "Resistor Color Trio":
   test "orange and orange and black":
     check label([Orange, Orange, Black]) == (33, "ohms")

--- a/exercises/resistor-color/resistor_color_test.nim
+++ b/exercises/resistor-color/resistor_color_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import resistor_color
 
-# version 1.0.0
-
 suite "Resistor Color":
   test "black":
     check colorCode(Black) == 0

--- a/exercises/reverse-string/reverse_string_test.nim
+++ b/exercises/reverse-string/reverse_string_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import reverse_string
 
-# version 1.2.0
-
 suite "Reverse String":
   test "an empty string":
     check reverse("") == ""

--- a/exercises/rna-transcription/rna_transcription_test.nim
+++ b/exercises/rna-transcription/rna_transcription_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import rna_transcription
 
-# version 1.3.0
-
 suite "RNA Transcription":
   test "empty RNA sequence":
     check toRna("") == ""

--- a/exercises/roman-numerals/roman_numerals_test.nim
+++ b/exercises/roman-numerals/roman_numerals_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import roman_numerals
 
-# version 1.2.0
-
 suite "Roman Numerals":
   test "1 is a single I":
     check roman(1) == "I"

--- a/exercises/rotational-cipher/rotational_cipher_test.nim
+++ b/exercises/rotational-cipher/rotational_cipher_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import rotational_cipher
 
-# version 1.2.0
-
 suite "Rotational Cipher":
   test "rotate a by 0, same output as input":
     check rotate("a", 0) == "a"

--- a/exercises/run-length-encoding/run_length_encoding_test.nim
+++ b/exercises/run-length-encoding/run_length_encoding_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import run_length_encoding
 
-# version 1.1.0
-
 suite "run-length encode a string":
   test "empty string":
     check encode("") == ""

--- a/exercises/saddle-points/saddle_points_test.nim
+++ b/exercises/saddle-points/saddle_points_test.nim
@@ -1,8 +1,6 @@
 import unittest, algorithm
 import saddle_points
 
-# version 1.5.0
-
 suite "Saddle Points":
   test "can identify single saddle point":
     const input = @[

--- a/exercises/say/say_test.nim
+++ b/exercises/say/say_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import say
 
-# version 1.2.0
-
 suite "Say":
   test "zero":
     check say(0) == "zero"

--- a/exercises/scale-generator/scale_generator_test.nim
+++ b/exercises/scale-generator/scale_generator_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import scale_generator
 
-# version 2.0.0
-
 suite "Scale Generator":
   test "chromatic scale with sharps":
     check scale("C") == @["C", "C#", "D", "D#", "E", "F",

--- a/exercises/scrabble-score/scrabble_score_test.nim
+++ b/exercises/scrabble-score/scrabble_score_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import scrabble_score
 
-# version 1.1.0
-
 suite "Scrabble Score":
   test "lowercase letter":
     check score("a") == 1

--- a/exercises/secret-handshake/secret_handshake_test.nim
+++ b/exercises/secret-handshake/secret_handshake_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import secret_handshake
 
-# version 1.2.0
-
 suite "Secret Handshake":
   test "wink for 1":
     check commands(1) == @["wink"]

--- a/exercises/series/series_test.nim
+++ b/exercises/series/series_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import series
 
-# version 1.0.0
-
 suite "Series":
   test "slices of one from one":
     check slices("1", 1) == @["1"]

--- a/exercises/sieve/sieve_test.nim
+++ b/exercises/sieve/sieve_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import sieve
 
-# version 1.1.0
-
 suite "Sieve":
   test "no primes under two":
     check primes(1).len == 0

--- a/exercises/space-age/space_age_test.nim
+++ b/exercises/space-age/space_age_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import space_age
 
-# version 1.2.0
-
 suite "Space Age":
   # Helper operator: return true when two floats are approximately equal
   func `~=`(x, y: float): bool =

--- a/exercises/spiral-matrix/spiral_matrix_test.nim
+++ b/exercises/spiral-matrix/spiral_matrix_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import spiral_matrix
 
-# version 1.1.0
-
 suite "Spiral Matrix":
   test "empty spiral":
     check spiral(0) == []

--- a/exercises/sublist/sublist_test.nim
+++ b/exercises/sublist/sublist_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import sublist
 
-# version 1.1.0
-
 suite "Sublist":
   test "empty lists":
     check sublist([], []) == Equal

--- a/exercises/sum-of-multiples/sum_of_multiples_test.nim
+++ b/exercises/sum-of-multiples/sum_of_multiples_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import sum_of_multiples
 
-# version 1.5.0
-
 suite "Sum of Multiples":
   test "no multiples within limit":
     check sum(1, @[3, 5]) == 0

--- a/exercises/triangle/triangle_test.nim
+++ b/exercises/triangle/triangle_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import triangle
 
-# version 1.2.1
-
 suite "Equilateral triangle":
   test "all sides are equal":
     check isEquilateral([2, 2, 2]) == true

--- a/exercises/twelve-days/twelve_days_test.nim
+++ b/exercises/twelve-days/twelve_days_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import twelve_days
 
-# version 1.2.0
-
 suite "Twelve Days":
   # Single verse: zero newline characters at the end.
   test "first day a partridge in a pear tree":

--- a/exercises/two-fer/two_fer_test.nim
+++ b/exercises/two-fer/two_fer_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import two_fer
 
-# version 1.2.0
-
 suite "Two Fer":
   test "no name given":
     check twoFer() == "One for you, one for me."

--- a/exercises/word-count/word_count_test.nim
+++ b/exercises/word-count/word_count_test.nim
@@ -1,8 +1,6 @@
 import unittest, tables
 import word_count
 
-# version 1.4.0
-
 suite "Word Count":
   test "count one word":
     let output = countWords("word")

--- a/exercises/yacht/yacht_test.nim
+++ b/exercises/yacht/yacht_test.nim
@@ -1,8 +1,6 @@
 import unittest
 import yacht
 
-# version 1.2.0
-
 suite "Yacht":
   test "Yacht":
     check score([5, 5, 5, 5, 5], Yacht) == 50


### PR DESCRIPTION
The upstream `canonical-data.json` files no longer have a version string.

At the time of writing, the Nim track has:
- 66 exercises that have canonical data, and are up-to-date with the most recent (now-removed) version strings. This PR removes the version string from the test files of those exercises (including from the `binary` exercise, which is the only deprecated exercise).
- 1 exercise (`react`) that has canonical data, but is out-of-date. The Nim track never added a version string to its test file, and so this PR does not affect it.
- 1 exercise (`robot-name`) that does not have canonical data; there is no version string to be removed because it never existed upstream.

This PR should be merged directly before #255 in order to minimize inconvenience for the user (messages like "Note: This exercise has changed since this solution was written.")