### PR TITLE
README(darts): Add empty line before header

### DIFF
--- a/exercises/darts/README.md
+++ b/exercises/darts/README.md
@@ -15,6 +15,7 @@ In our particular instance of the game, the target rewards with 4 different amou
 The outer circle has a radius of 10 units (This is equivalent to the total radius for the entire target), the middle circle a radius of 5 units, and the inner circle a radius of 1. Of course, they are all centered to the same point (That is, the circles are [concentric](http://mathworld.wolfram.com/ConcentricCircles.html)) defined by the coordinates (0, 0).
 
 Write a function that given a point in the target (defined by its `real` cartesian coordinates `x` and `y`), returns the correct amount earned by a dart landing in that point.
+
 ## Running the tests
 
 To compile and run the tests, just run the following in your exercise directory:


### PR DESCRIPTION
All the other exercise `README.md` files contain this empty line.

Upstream: https://github.com/exercism/problem-specifications/commit/381c30e469a8