### PR TITLE
CI(configlet): use GitHub Action to install configlet; add `configlet generate`

### DIFF
--- a/.github/workflows/configlet.yml
+++ b/.github/workflows/configlet.yml
@@ -28,3 +28,24 @@ jobs:
 
     - name: configlet fmt
       run: configlet fmt . && git diff --exit-code
+
+
+  configlet-generate:
+    name: generate
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout exercism/nim
+      uses: actions/checkout@v2
+
+    - name: Checkout exercism/problem-specifications
+      uses: actions/checkout@v2
+      with:
+        repository: exercism/problem-specifications
+        path: problem-specifications
+
+    - name: Install configlet
+      uses: exercism/github-actions/configlet-ci@master
+
+    - name: configlet generate
+      run: configlet generate . --spec-path ./problem-specifications && git diff --exit-code

--- a/.github/workflows/configlet.yml
+++ b/.github/workflows/configlet.yml
@@ -1,8 +1,9 @@
-name: Configlet (lint and fmt)
+name: configlet
 on: [push, pull_request]
 
 jobs:
-  configlet:
+  configlet-lint:
+    name: lint
     runs-on: ubuntu-latest
 
     steps:
@@ -13,6 +14,17 @@ jobs:
 
     - name: configlet lint
       run: configlet lint .
+
+
+  configlet-fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install configlet
+      uses: exercism/github-actions/configlet-ci@master
 
     - name: configlet fmt
       run: configlet fmt . && git diff --exit-code

--- a/.github/workflows/configlet.yml
+++ b/.github/workflows/configlet.yml
@@ -2,20 +2,17 @@ name: Configlet (lint and fmt)
 on: [push, pull_request]
 
 jobs:
-  job1:
-    name: configlet
+  configlet:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: fetch-configlet
-      run: bin/fetch-configlet
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install configlet
+      uses: exercism/github-actions/configlet-ci@master
 
     - name: configlet lint
-      run: bin/configlet lint .
+      run: configlet lint .
 
     - name: configlet fmt
-      run: bin/configlet fmt . && git diff --exit-code
+      run: configlet fmt . && git diff --exit-code


### PR DESCRIPTION
The CI check for `configlet generate` should fail until https://github.com/exercism/nim/pull/257 is merged.

To-do:
- [x] Merge https://github.com/exercism/nim/pull/257
- [x] Rebase this PR on `master`