### PR TITLE
CI: Move amd64 `check_exercises` jobs to GitHub Actions

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -1,0 +1,68 @@
+name: exercises
+on: [push, pull_request]
+
+jobs:
+  exercises:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            builder: ubuntu-20.04
+            nim_channel: stable
+          - os: linux
+            builder: ubuntu-20.04
+            nim_channel: devel
+          - os: macOS
+            builder: macos-10.15
+            nim_channel: stable
+
+    name: ${{ matrix.os }}-nim-${{ matrix.nim_channel }}
+    runs-on: ${{ matrix.builder }}
+    env:
+      CHANNEL: ${{ matrix.nim_channel }}
+      NIM_DIR: bin/nim-${{ matrix.nim_channel }}
+
+    steps:
+      - name: Checkout exercism/nim
+        uses: actions/checkout@v2
+
+      - name: Set NIM_VERSION environmental variable
+        run: |
+          if ${{ env.CHANNEL == 'stable' }}; then
+            NIM_VERSION="$(curl -sSfL --retry 3 https://nim-lang.org/channels/stable)"
+          else
+            NIM_VERSION="$(git ls-remote https://github.com/nim-lang/Nim refs/heads/devel | cut -f1)"
+          fi
+          echo "NIM_VERSION=${NIM_VERSION}" >> ${GITHUB_ENV}
+
+      - name: Restore Nim from cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.NIM_DIR }}
+          key: ${{ runner.os }}-nim-${{ env.CHANNEL }}-${{ env.NIM_VERSION }}
+
+      - name: Install up-to-date Nim
+        run: |
+          sh bin/install-nim.sh
+          echo "${NIM_DIR}/bin" >> ${GITHUB_PATH}
+
+      - name: Show versions of Nim and Nimble
+        run: |
+          echo "Nim version:"
+          nim --version
+          echo "Nimble version:"
+          nimble --version
+
+      - name: Compile `check_exercises.nim`
+        run: nim c --styleCheck:hint _test/check_exercises.nim
+
+      - name: Run `check_exercises`
+        run: _test/check_exercises
+
+      - name: Show cache contents
+        run: |
+          echo "Directories in ${NIM_DIR}, sorted by size:"
+          du -h -d 1 "${NIM_DIR}" | sort -hr
+          echo "All files in ${NIM_DIR}, sorted by size:"
+          find "${NIM_DIR}" -type f -exec du -h {} + | sort -hr

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,21 +9,7 @@ cache:
 jobs:
   include:
     - stage: "Run `check_exercises`"
-      name: "nim-stable"
-      os: linux
-      dist: bionic
-      env: CHANNEL=stable
-
-    - name: "nim-devel"
-      os: linux
-      dist: bionic
-      env: CHANNEL=devel
-
-    - name: "macOS"
-      os: osx
-      env: CHANNEL=stable
-
-    - name: "arm64"
+      name: "arm64"
       os: linux
       dist: bionic
       env: CHANNEL=stable


### PR DESCRIPTION
This PR adds a workflow that runs `check_exercises.nim` on:
- Linux, with Nim stable (currently 1.4.0)
- Linux, with Nim devel
- macOS, with Nim stable

and removes those jobs from the Travis CI configuration.

For now, this PR keeps the Travis jobs that run on `arm64` and `ppc64le`.

This gets most of the way to resolving https://github.com/exercism/nim/issues/251.

I intend to make separate PRs later that:
- compile with `--styleCheck:error`, not `--styleCheck:hint`
- add Windows
- remove Travis completely