### PR TITLE
config.json: populate `tags`

### DIFF
--- a/config.json
+++ b/config.json
@@ -928,5 +928,24 @@
   },
   "concepts": [],
   "key_features": [],
-  "tags": []
+  "tags": [
+    "paradigm/imperative",
+    "paradigm/procedural",
+    "typing/static",
+    "typing/strong",
+    "execution_mode/compiled",
+    "platform/windows",
+    "platform/mac",
+    "platform/linux",
+    "platform/web",
+    "runtime/standalone_executable",
+    "used_for/backends",
+    "used_for/cross_platform_development",
+    "used_for/embedded_systems",
+    "used_for/frontends",
+    "used_for/games",
+    "used_for/scientific_calculations",
+    "used_for/scripts",
+    "used_for/web_development"
+  ]
 }


### PR DESCRIPTION
This deliberately omits some tags that we could conceivably add, such as:
- `paradigm/functional`
- `paradigm/object_oriented`
- `execution_mode/interpreted`
- `platform/ios`
- `platform/android`
- `runtime/language_specific`

The spec currently contains:
> Tracks can be annotated with tags, which allows searching for tracks
> with a certain tag combination.

> A track should choose their tags based on the general usage of their
> language. For example, imagine a student thinking: "I'd like to do
> machine learning, what language should I pick?", or "I'd like to learn
> functional programming, which language should I choose?". If your
> language would be a good candidate, give it that tag. If your language
> supports some functional ideas but they're rarely used, or a few
> people do Machine Learning in it, but it's rare, then do not apply
> those tags.

See [the spec](https://github.com/exercism/docs/blob/main/anatomy/tracks/config-json.md#tags).

Closes: #271