### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "1894c1ce-54aa-40f3-94ef-67ddc244d602",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Nim locally",
+      "blurb": "Learn how to install Nim locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "d2bd8b18-cddf-4c31-a986-bca632b53785",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Nim",
+      "blurb": "An overview of how to get started from scratch with Nim"
+    },
+    {
+      "uuid": "ced8695a-dcf5-428a-9054-6168de1d7969",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Nim track",
+      "blurb": "Learn how to test your Nim exercises on Exercism"
+    },
+    {
+      "uuid": "f9e5a17d-8155-4eab-871b-b84630715e64",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Nim resources",
+      "blurb": "A collection of useful resources to help you master Nim"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
