### PR TITLE
🤖 Add fetch configlet script(s) to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,7 @@ config/maintainers.json @exercism/maintainers-admin
 
 # Code owners
 .github/CODEOWNERS      @exercism/maintainers-admin
+
+# Changes to `fetch-configlet` should be made in the `exercism/configlet` repo
+bin/fetch-configlet     @exercism/maintainers-admin
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Maintainers 
+# Maintainers
 config/maintainers.json @exercism/maintainers-admin
 
 # Code owners
@@ -6,4 +6,3 @@ config/maintainers.json @exercism/maintainers-admin
 
 # Changes to `fetch-configlet` should be made in the `exercism/configlet` repo
 bin/fetch-configlet     @exercism/maintainers-admin
-


### PR DESCRIPTION
This PR adds the fetch configlet script(s) to the `.github/CODEOWNERS` file.

The fetch configlet script(s) are copied of the files in the https://github.com/exercism/configlet/blob/main/scripts directory.
We want to prevent tracks from changing these fetch scripts as they should be updated centrally, to have updates benefit all tracks.

## Tracking

https://github.com/exercism/configlet/issues/286
