### PR TITLE
🤖 labels: add initial `.appends` file

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -53,4 +53,3 @@
 - name: "wontfix"
   description: ""
   color: "ffffff"
-

--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -1,31 +1,31 @@
-- name: "kind: bug"
-  description: ""
-  color: "fc2929"
-
 - name: "dependencies"
   description: "Pull requests that update a dependency file"
   color: "0366d6"
+
+- name: "kind: bug"
+  description: ""
+  color: "fc2929"
 
 - name: "kind: discussion"
   description: ""
   color: "5319e7"
 
-- name: "status: duplicate"
-  description: ""
-  color: "cccccc"
-
 - name: "kind: enhancement"
   description: ""
   color: "84b6eb"
+
+- name: "status: duplicate"
+  description: ""
+  color: "cccccc"
 
 - name: "status: invalid"
   description: ""
   color: "e6e6e6"
 
-- name: "v3-migration 🤖"
-  description: "Preparing for Exercism v3"
-  color: "E99695"
-
 - name: "status: wontfix"
   description: ""
   color: "ffffff"
+
+- name: "v3-migration 🤖"
+  description: "Preparing for Exercism v3"
+  color: "E99695"

--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -1,15 +1,3 @@
-- name: "abandoned"
-  description: ""
-  color: "d93f0b"
-
-- name: "awaiting review"
-  description: ""
-  color: "9715c6"
-
-- name: "beginner friendly"
-  description: ""
-  color: "0e8a16"
-
 - name: "bug"
   description: ""
   color: "fc2929"
@@ -30,21 +18,9 @@
   description: ""
   color: "84b6eb"
 
-- name: "help wanted"
-  description: ""
-  color: "159818"
-
 - name: "invalid"
   description: ""
   color: "e6e6e6"
-
-- name: "pinned"
-  description: ""
-  color: "fbca04"
-
-- name: "question"
-  description: ""
-  color: "cc317c"
 
 - name: "v3-migration 🤖"
   description: "Preparing for Exercism v3"

--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -10,7 +10,7 @@
   description: ""
   color: "5319e7"
 
-- name: "duplicate"
+- name: "status: duplicate"
   description: ""
   color: "cccccc"
 
@@ -18,7 +18,7 @@
   description: ""
   color: "84b6eb"
 
-- name: "invalid"
+- name: "status: invalid"
   description: ""
   color: "e6e6e6"
 
@@ -26,6 +26,6 @@
   description: "Preparing for Exercism v3"
   color: "E99695"
 
-- name: "wontfix"
+- name: "status: wontfix"
   description: ""
   color: "ffffff"

--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -22,7 +22,7 @@
   description: ""
   color: "e6e6e6"
 
-- name: "status: wontfix"
+- name: "status: wont do/fix"
   description: ""
   color: "ffffff"
 

--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -1,0 +1,56 @@
+- name: "abandoned"
+  description: ""
+  color: "d93f0b"
+
+- name: "awaiting review"
+  description: ""
+  color: "9715c6"
+
+- name: "beginner friendly"
+  description: ""
+  color: "0e8a16"
+
+- name: "bug"
+  description: ""
+  color: "fc2929"
+
+- name: "dependencies"
+  description: "Pull requests that update a dependency file"
+  color: "0366d6"
+
+- name: "discussion"
+  description: ""
+  color: "5319e7"
+
+- name: "duplicate"
+  description: ""
+  color: "cccccc"
+
+- name: "enhancement"
+  description: ""
+  color: "84b6eb"
+
+- name: "help wanted"
+  description: ""
+  color: "159818"
+
+- name: "invalid"
+  description: ""
+  color: "e6e6e6"
+
+- name: "pinned"
+  description: ""
+  color: "fbca04"
+
+- name: "question"
+  description: ""
+  color: "cc317c"
+
+- name: "v3-migration 🤖"
+  description: "Preparing for Exercism v3"
+  color: "E99695"
+
+- name: "wontfix"
+  description: ""
+  color: "ffffff"
+

--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -1,4 +1,4 @@
-- name: "bug"
+- name: "kind: bug"
   description: ""
   color: "fc2929"
 
@@ -6,7 +6,7 @@
   description: "Pull requests that update a dependency file"
   color: "0366d6"
 
-- name: "discussion"
+- name: "kind: discussion"
   description: ""
   color: "5319e7"
 
@@ -14,7 +14,7 @@
   description: ""
   color: "cccccc"
 
-- name: "enhancement"
+- name: "kind: enhancement"
   description: ""
   color: "84b6eb"
 


### PR DESCRIPTION
This PR adds a `.appends/.github/labels.yml` file, which contains
every label that is currently present in this repo. A future
`.github/labels.yml` file will contain the full list of labels that this
repo can use, which will be a combination of the
`.appends/.github/labels.yml` file and a centrally-managed `labels.yml`
file.

We'll automatically sync any changes, which allows us to guarantee that
every track repository will have a pre-determined set of labels,
augmented with any custom, repo-specific labels in the
`.appends/.github/labels.yml` file.

## Tracking

https://github.com/exercism/v3-launch/issues/41