### PR TITLE
check_exercises: support `nim r`

### DIFF
--- a/_test/check_exercises.nim
+++ b/_test/check_exercises.nim
@@ -65,7 +65,7 @@ Options:
 
 let
   appDir = getAppDir()
-  exercisesDir = appDir / ".." / "exercises"
+  exercisesDir = appDir.parentDir() / "exercises"
 var
   outDir = ""
   testDir = ""

--- a/_test/check_exercises.nim
+++ b/_test/check_exercises.nim
@@ -63,9 +63,10 @@ Options:
   -t, --tmp       Set output path to a temporary location (e.g. in `/tmp`)"""
   quit(0)
 
-let
-  appDir = getAppDir()
-  exercisesDir = appDir.parentDir() / "exercises"
+const
+  thisDir = currentSourcePath().parentDir()
+  exercisesDir = thisDir.parentDir() / "exercises"
+
 var
   outDir = ""
   testDir = ""
@@ -104,7 +105,7 @@ proc prepareDir(options: Options) =
   ## Creates the new directory structure for the tests.
   # Note that `getTempDir()` is generally discouraged, but it shouldn't cause
   # problems here and the `-t` option is not the default.
-  let outBase = if optTmp in options: getTempDir() else: appDir
+  let outBase = if optTmp in options: getTempDir() else: thisDir
   outDir = outBase / "check_exercises_tmp"
   testDir = outDir / "tests"
   srcDir = outDir / "src" / "check_exercises"


### PR DESCRIPTION
Before this commit, running

    nim r check_exercises.nim

would produce

    Tested 0 exercises.
    All tests passed.

It wasn't supported because this file was written before `nim r` was
added (in Nim 1.4).

---

I'd also like to sneak in the `parentDir` change here - I should probably have included it in https://github.com/exercism/nim/pull/345

Closes: #344


