### PR TITLE
update 'exercism.io' to 'exercism.org'

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ Exercism is a platform centered around empathetic conversation. We have a low to
 
 ## Seen or experienced something uncomfortable?
 
-If you see or experience abuse, harassment, discrimination, or feel unsafe or upset, please email abuse@exercism.io. We will take your report seriously.
+If you see or experience abuse, harassment, discrimination, or feel unsafe or upset, please email abuse@exercism.org. We will take your report seriously.
 
 ## Enforcement
 

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -2,7 +2,7 @@
 
 Need help? These guides should help you:
 
-- [Installing Nim](https://exercism.io/tracks/nim/installation)
-- [Running the Tests](https://exercism.io/tracks/nim/tests)
-- [Learning Nim](https://exercism.io/tracks/nim/learning)
-- [Useful Nim Resources](https://exercism.io/tracks/nim/resources)
+- [Installing Nim](https://exercism.org/tracks/nim/installation)
+- [Running the Tests](https://exercism.org/tracks/nim/tests)
+- [Learning Nim](https://exercism.org/tracks/nim/learning)
+- [Useful Nim Resources](https://exercism.org/tracks/nim/resources)

--- a/reference/exercise-concepts/bob.md
+++ b/reference/exercise-concepts/bob.md
@@ -52,14 +52,14 @@
 
 ### Implicit return
 
-[Example Implementation](https://exercism.io/tracks/nim/exercises/bob/solutions/fd46a50ebb2f47b8b415cc046ca7f65d)
+[Example Implementation](https://exercism.org/tracks/nim/exercises/bob/solutions/fd46a50ebb2f47b8b415cc046ca7f65d)
 
 - if expression
 - implicit return
 
 ### `parseutils` module
 
-[Example Implementation](https://exercism.io/tracks/nim/exercises/bob/solutions/5eeba8cf35ff469e8ac732e9abe62d51)
+[Example Implementation](https://exercism.org/tracks/nim/exercises/bob/solutions/5eeba8cf35ff469e8ac732e9abe62d51)
 
 - multiline comment
 - sets
@@ -69,13 +69,13 @@
 
 ### Implicit `result` variable
 
-[Example Implementation](https://exercism.io/tracks/nim/exercises/bob/solutions/fdfdef2cedac4324a7c1f49545ae9188)
+[Example Implementation](https://exercism.org/tracks/nim/exercises/bob/solutions/fdfdef2cedac4324a7c1f49545ae9188)
 
 - implicit `result` variable
 
 ### Types
 
-[Example Implementation](https://exercism.io/tracks/nim/exercises/bob/solutions/b3f58e77a19d4293be369db4f738084e)
+[Example Implementation](https://exercism.org/tracks/nim/exercises/bob/solutions/b3f58e77a19d4293be369db4f738084e)
 
 - types
 - tuples
@@ -83,7 +83,7 @@
 
 ### Generic parameters
 
-[Example Implementation](https://exercism.io/tracks/nim/exercises/bob/solutions/e70f5bc5f63c4692a947fa121c8fdb40)
+[Example Implementation](https://exercism.org/tracks/nim/exercises/bob/solutions/e70f5bc5f63c4692a947fa121c8fdb40)
 
 - generics
 - anon. procs
@@ -91,6 +91,6 @@
 
 ### `import as`
 
-[Example Implementation](https://exercism.io/tracks/nim/exercises/bob/solutions/03b007333a7b489db24c6e0c9e07908b)
+[Example Implementation](https://exercism.org/tracks/nim/exercises/bob/solutions/03b007333a7b489db24c6e0c9e07908b)
 
 - `import as`

--- a/reference/exercise-concepts/protein-translation.md
+++ b/reference/exercise-concepts/protein-translation.md
@@ -11,7 +11,7 @@
   - compile-time vs. runtime
 - strings
 - table constructor
-  - multiple keys at one time (as seen [here](https://exercism.io/tracks/nim/exercises/protein-translation/solutions/fc829b982b274a80883f7f82d6e8faaf))
+  - multiple keys at one time (as seen [here](https://exercism.org/tracks/nim/exercises/protein-translation/solutions/fc829b982b274a80883f7f82d6e8faaf))
     <br />
     eg. `{"nim", "Nim": "awesome"}`
 - method call syntax
@@ -56,7 +56,7 @@
 
 ### Case Statment
 
-[Example Implementation](https://exercism.io/tracks/nim/exercises/protein-translation/solutions/1078c01ba467400881b40827ffd1b84f)
+[Example Implementation](https://exercism.org/tracks/nim/exercises/protein-translation/solutions/1078c01ba467400881b40827ffd1b84f)
 
 - case statement
 - of branch


### PR DESCRIPTION
We transitioned to 'exercism.org' with the release of Exercism v3.

--

Better alternative to #351.