### PR TITLE
exercises(protein-translation): update tests and example

### DIFF
--- a/exercises/practice/protein-translation/.meta/example.nim
+++ b/exercises/practice/protein-translation/.meta/example.nim
@@ -21,17 +21,19 @@ const codonToAminoAcid = {
 }.toTable
 
 func translate*(s: string): seq[string] =
-  if s.len mod 3 != 0:
-    raise newException(ValueError, "Invalid RNA sequence: " & s)
-
+  var codon = newString(3)
   for i in countup(0, s.high, 3):
-    let codon = s[i..i+2]
-
-    if codon notin codonToAminoAcid:
-      raise newException(ValueError, "Unknown codon: " & codon)
-
-    let aminoAcid = codonToAminoAcid[codon]
-    if aminoAcid == "STOP":
-      return
+    if i+2 < s.len:
+      codon[0] = s[i]
+      codon[1] = s[i+1]
+      codon[2] = s[i+2]
+      if codon in codonToAminoAcid:
+        let aminoAcid = codonToAminoAcid[codon]
+        if aminoAcid == "STOP":
+          return
+        else:
+          result.add aminoAcid
+      else:
+        raise newException(ValueError, "Unknown codon: " & codon)
     else:
-      result &= aminoAcid
+      raise newException(ValueError, "Invalid RNA sequence: " & s)

--- a/exercises/practice/protein-translation/.meta/tests.toml
+++ b/exercises/practice/protein-translation/.meta/tests.toml
@@ -9,6 +9,9 @@
 # As user-added comments (using the # character) will be removed when this file
 # is regenerated, comments can be added via a `comment` key.
 
+[2c44f7bf-ba20-43f7-a3bf-f2219c0c3f98]
+description = "Empty RNA sequence results in no proteins"
+
 [96d3d44f-34a2-4db4-84cd-fff523e069be]
 description = "Methionine RNA sequence"
 
@@ -60,6 +63,12 @@ description = "STOP codon RNA sequence 2"
 [9c2ad527-ebc9-4ace-808b-2b6447cb54cb]
 description = "STOP codon RNA sequence 3"
 
+[f4d9d8ee-00a8-47bf-a1e3-1641d4428e54]
+description = "Sequence of two protein codons translates into proteins"
+
+[dd22eef3-b4f1-4ad6-bb0b-27093c090a9d]
+description = "Sequence of two different protein codons translates into proteins"
+
 [d0f295df-fb70-425c-946c-ec2ec185388e]
 description = "Translate RNA strand into correct protein list"
 
@@ -77,3 +86,15 @@ description = "Translation stops if STOP codon in middle of three-codon sequence
 
 [2c2a2a60-401f-4a80-b977-e0715b23b93d]
 description = "Translation stops if STOP codon in middle of six-codon sequence"
+
+[1e75ea2a-f907-4994-ae5c-118632a1cb0f]
+description = "Non-existing codon can't translate"
+
+[9eac93f3-627a-4c90-8653-6d0a0595bc6f]
+description = "Unknown amino acids, not part of a codon, can't translate"
+
+[9d73899f-e68e-4291-b1e2-7bf87c00f024]
+description = "Incomplete RNA sequence can't translate"
+
+[43945cf7-9968-402d-ab9f-b8a28750b050]
+description = "Incomplete RNA sequence can translate if valid until a STOP codon"

--- a/exercises/practice/protein-translation/test_protein_translation.nim
+++ b/exercises/practice/protein-translation/test_protein_translation.nim
@@ -2,6 +2,9 @@ import unittest
 import protein_translation
 
 suite "Protein Translation":
+  test "empty RNA sequence results in no proteins":
+    check translate("").len == 0
+
   test "Methionine RNA sequence":
     check translate("AUG") == @["Methionine"]
 
@@ -53,6 +56,12 @@ suite "Protein Translation":
   test "STOP codon RNA sequence 3":
     check translate("UGA").len == 0
 
+  test "sequence of two protein codons translates into proteins":
+    check translate("UUUUUU") == @["Phenylalanine", "Phenylalanine"]
+
+  test "sequence of two different protein codons translates into proteins":
+    check translate("UUAUUG") == @["Leucine", "Leucine"]
+
   test "translate RNA strand into correct protein list":
     check translate("AUGUUUUGG") == @["Methionine", "Phenylalanine", "Tryptophan"]
 
@@ -70,3 +79,18 @@ suite "Protein Translation":
 
   test "translation stops if STOP codon in middle of six-codon sequence":
     check translate("UGGUGUUAUUAAUGGUUU") == @["Tryptophan", "Cysteine", "Tyrosine"]
+
+  test "non-existing codon can't translate":
+    expect ValueError:
+      discard translate("AAA")
+
+  test "unknown amino acids, not part of a codon, can't translate":
+    expect ValueError:
+      discard translate("XYZ")
+
+  test "incomplete RNA sequence can't translate":
+    expect ValueError:
+      discard translate("AUGU")
+
+  test "incomplete RNA sequence can translate if valid until a STOP codon":
+    check translate("UUCUUCUAAUGGU") == @["Phenylalanine", "Phenylalanine"]


### PR DESCRIPTION
Sync the tests, and make the required change to the example.

The example implementation already had some input validation, even
though it was not required. However, we must modify the example because
the final new test:

```nim
test "Incomplete RNA sequence can translate if valid until a STOP codon":
  check translate("UUCUUCUAAUGGU") == @["Phenylalanine", "Phenylalanine"]
```

means that `translate` should not immediately raise an exception when
the input length is not divisible by 3.