### PR TITLE
exercises(diffie-hellman): sync tests

### DIFF
--- a/exercises/practice/diffie-hellman/.meta/tests.toml
+++ b/exercises/practice/diffie-hellman/.meta/tests.toml
@@ -18,6 +18,10 @@ description = "private key is random"
 [b4161d8e-53a1-4241-ae8f-48cc86527f22]
 description = "can calculate public key using private key"
 
+[0d25f8d7-4897-4338-a033-2d3d7a9af688]
+description = "can calculate public key when given a different private key"
+include = false
+
 [cd02ad45-3f52-4510-99cc-5161dad948a8]
 description = "can calculate secret using other party's public key"
 


### PR DESCRIPTION
Please let me be the one to merge these PRs.

---

Links:

- diffie-hellman's [canonical-data.json#L50-L67](https://github.com/exercism/problem-specifications/blob/26d7c92bdc4a/exercises/diffie-hellman/canonical-data.json#L50-L67)
- [exercism/problem-specifications#1740](https://github-redirect.dependabot.com/exercism/problem-specifications/pull/1740)
- The JavaScript track's [diffie-hellman.spec.js#L53-L71](https://github.com/exercism/javascript/blob/50f6ef80f998/exercises/practice/diffie-hellman/diffie-hellman.spec.js#L53-L71)

This test is intended to check that `publicKey(p, g, privateKey)` does not mutate `p` or `g`. But we don't need that check on the Nim track because `p` and `g` are `const`, and are not var parameters.

So it would only test that the user did not something bizarre, changing all the `const` to `var` in the test file and then implementing something like:

```Nim
proc publicKey*(p, g, a: var int): int =
```

We could implement a test like

```Nim
test "calculating the public key twice produces the same result":
  const p = 23
  const g = 5
  const privateKey = 15
  check publicKey(p, g, privateKey) == 19
  check publicKey(p, g, privateKey) == 19
```

But this test doesn't currently exist in the canonical data.