### PR TITLE
exercises(high-scores): sync tests

### DIFF
--- a/exercises/practice/high-scores/.meta/tests.toml
+++ b/exercises/practice/high-scores/.meta/tests.toml
@@ -20,16 +20,32 @@ description = "Latest score"
 description = "Personal best"
 
 [3d996a97-c81c-4642-9afc-80b80dc14015]
-description = "Personal top three from a list of scores"
+description = "Top 3 scores -> Personal top three from a list of scores"
 
 [1084ecb5-3eb4-46fe-a816-e40331a4e83a]
-description = "Personal top highest to lowest"
+description = "Top 3 scores -> Personal top highest to lowest"
 
 [e6465b6b-5a11-4936-bfe3-35241c4f4f16]
-description = "Personal top when there is a tie"
+description = "Top 3 scores -> Personal top when there is a tie"
 
 [f73b02af-c8fd-41c9-91b9-c86eaa86bce2]
-description = "Personal top when there are less than 3"
+description = "Top 3 scores -> Personal top when there are less than 3"
 
 [16608eae-f60f-4a88-800e-aabce5df2865]
-description = "Personal top when there is only one"
+description = "Top 3 scores -> Personal top when there is only one"
+
+[2df075f9-fec9-4756-8f40-98c52a11504f]
+description = "Top 3 scores -> Latest score after personal top scores"
+include = false
+
+[809c4058-7eb1-4206-b01e-79238b9b71bc]
+description = "Top 3 scores -> Scores after personal top scores"
+include = false
+
+[ddb0efc0-9a86-4f82-bc30-21ae0bdc6418]
+description = "Top 3 scores -> Latest score after personal best"
+include = false
+
+[6a0fd2d1-4cc4-46b9-a5bb-2fb667ca2364]
+description = "Top 3 scores -> Scores after personal best"
+include = false

--- a/exercises/practice/high-scores/test_high_scores.nim
+++ b/exercises/practice/high-scores/test_high_scores.nim
@@ -1,13 +1,15 @@
 import unittest
 import high_scores
 
-suite "High Scores":
+suite "Latest Score":
   test "latest score":
     check latest(@[100, 0, 90, 30]) == 30
 
+suite "Personal Best"
   test "personal best":
     check personalBest(@[40, 100, 70]) == 100
 
+suite "Top 3 scores"
   test "personal top three from a list of scores":
     check personalTopThree(@[10, 30, 90, 30, 100, 20,
                              10, 0, 30, 40, 40, 70, 70]) == @[100, 90, 70]


### PR DESCRIPTION
Exclude the new immutability tests - the procs for this exercise don't
currently take a `var` parameter.