### PR TITLE
exercises(largest-series-product): sync tests

### DIFF
--- a/exercises/practice/largest-series-product/.meta/tests.toml
+++ b/exercises/practice/largest-series-product/.meta/tests.toml
@@ -53,3 +53,8 @@ description = "rejects invalid character in digits"
 
 [5fe3c0e5-a945-49f2-b584-f0814b4dd1ef]
 description = "rejects negative span"
+include = false
+
+[c859f34a-9bfe-4897-9c2f-6d7f8598e7f0]
+description = "rejects negative span"
+reimplements = "5fe3c0e5-a945-49f2-b584-f0814b4dd1ef"


### PR DESCRIPTION
The Nim track does not currently test the contents of exception
messages, so we don't need to alter the test file.