### PR TITLE
exercises(armstrong-numbers): sync tests

### DIFF
--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -35,3 +35,11 @@ description = "Seven-digit number that is an Armstrong number"
 
 [7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
 description = "Seven-digit number that is not an Armstrong number"
+
+[5ee2fdf8-334e-4a46-bb8d-e5c19c02c148]
+description = "Armstrong number containing seven zeroes"
+include = false
+
+[12ffbf10-307a-434e-b4ad-c925680e1dd4]
+description = "The largest and last Armstrong number"
+include = false


### PR DESCRIPTION
Exclude the [new big integer tests](https://github.com/exercism/problem-specifications/commit/33667ceacf75), where each input number is larger than the maximum int64 value (9223372036854775807):

```json
    {
      "uuid": "5ee2fdf8-334e-4a46-bb8d-e5c19c02c148",
      "description": "Armstrong number containing seven zeroes",
      "comments": [
        "The numeric size of this input number is 108 bits. Consider skipping this test if appropriate."
      ],
      "scenarios": ["big-integer"],
      "property": "isArmstrongNumber",
      "input": {
        "number": 186709961001538790100634132976990
      },
      "expected": true
    },
    {
      "uuid": "12ffbf10-307a-434e-b4ad-c925680e1dd4",
      "description": "The largest and last Armstrong number",
      "comments": [
        "The numeric size of this input number is 127 bits. Consider skipping this test if appropriate."
      ],
      "scenarios": ["big-integer"],
      "property": "isArmstrongNumber",
      "input": {
        "number": 115132219018763992565095597973971522401
      },
      "expected": true
    }
```