### PR TITLE
reflect renaming of `master` branches to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please see the [contributing guide](https://exercism.org/docs/building/tracks).
 
 ## Testing
 
-The file [`_test/check_exercises.nim`](https://github.com/exercism/nim/blob/master/_test/check_exercises.nim) checks that the example solution for every implemented exercise passes that exercise's test suite. This repo runs that file during CI, and you can also run it on your own machine.
+The file [`_test/check_exercises.nim`](https://github.com/exercism/nim/blob/main/_test/check_exercises.nim) checks that the example solution for every implemented exercise passes that exercise's test suite. This repo runs that file during CI, and you can also run it on your own machine.
 
 To test all the exercises, run:
 ```bash
@@ -20,7 +20,7 @@ To test a selection of exercises, run:
 $ nim c -r check_exercises.nim [exercise-name] [...]
 ```
 
-This finds all the relevant tests, processes them into a new directory for testing, and runs them. For more information, please read the documentation comments in [`_test/check_exercises.nim`](https://github.com/exercism/nim/blob/master/_test/check_exercises.nim) or run `check_exercises` with the `--help` option.
+This finds all the relevant tests, processes them into a new directory for testing, and runs them. For more information, please read the documentation comments in [`_test/check_exercises.nim`](https://github.com/exercism/nim/blob/main/_test/check_exercises.nim) or run `check_exercises` with the `--help` option.
 
 ### Nim icon
 The Nim logo is assumed to be owned by Andreas Rumpf. It appears to be released under the MIT license, along with the Nim codebase. We've adapted the official Nim logo by changing the colors, which we believe falls under fair use.

--- a/_test/check_uuids.nim
+++ b/_test/check_uuids.nim
@@ -80,7 +80,7 @@ let
 
 proc downloadConfig(client: HttpClient, track: string) =
   ## Downloads the `config.json` file for the given Exercism track.
-  let url = &"https://raw.githubusercontent.com/exercism/{track}/master/config.json"
+  let url = &"https://raw.githubusercontent.com/exercism/{track}/main/config.json"
   client.downloadFile(url, downloadDir / &"{track}.json")
 
 proc downloadConfigs(tracks: seq[string]) =

--- a/reference/exercise-concepts/bob.md
+++ b/reference/exercise-concepts/bob.md
@@ -1,6 +1,6 @@
 # Concepts of protein-translation
 
-[Example Implementation](https://github.com/exercism/nim/blob/master/exercises/bob/example.nim)
+[Example Implementation](https://github.com/exercism/nim/blob/main/exercises/bob/example.nim)
 
 ## General:
 

--- a/reference/exercise-concepts/protein-translation.md
+++ b/reference/exercise-concepts/protein-translation.md
@@ -1,6 +1,6 @@
 # Concepts of protein-translation
 
-[Example Implementation](https://github.com/exercism/nim/blob/master/exercises/protein-translation/example.nim)
+[Example Implementation](https://github.com/exercism/nim/blob/main/exercises/protein-translation/example.nim)
 
 ## General:
 


### PR DESCRIPTION
With this PR, remaining occurances of 'master"' in this repo:

```console
$ git rev-parse --short HEAD
6fe5bac
$ git grep --break --heading 'master'
CODE_OF_CONDUCT.md
63:- Intimidation or harassment (online or in-person). Please read the [Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md) for how we interpret harassment.

docs/config.json
29:      "blurb": "A collection of useful resources to help you master Nim"
```

We shouldn't change the link in the `CODE_OF_CONDUCT.md` because this is an org-wide file, and https://github.com/stumpsyn/policies/blob/main/citizen_code_of_conduct.md doesn't exist anyway.