### PR TITLE
.github: add `markdownlint` workflow

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,14 @@
+name: markdownlint
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  markdownlint:
+    name: Lint markdown files
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@e3969ef4ed874458f4b66d4631f78fff7717012c

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,22 @@
+# For information on configuring markdownlint, see:
+# https://github.com/DavidAnson/markdownlint
+config:
+  MD003:
+    style: 'atx'    # Forbid setext-style headers and closed-ATX-style headers
+  MD004:
+    style: 'dash'   # Require `-` for every unordered list item
+  MD013: false      # Permit long lines
+  MD029:
+    style: 'one'    # Require each ordered list item to begin with `1.`
+  MD035:
+    style: '---'    # Require `---` for every horizontal rule
+  MD046:
+    style: 'fenced' # Forbid using indentation for code blocks
+
+globs:
+  - "**/*.md"
+
+# Ignore files that are synced
+ignores:
+  - "exercises/practice/*/.docs/instructions.md"
+  - "exercises/practice/*/.docs/introduction.md"


### PR DESCRIPTION
Make CI fail if repo-specific Markdown files violate some [`markdownlint` rules](https://github.com/DavidAnson/markdownlint/blob/v0.26.2/doc/Rules.md).

See also the [Exercism Markdown Specification](https://github.com/exercism/docs/blob/883a4efedbb5/building/markdown/markdown.md).