### PR TITLE
.github(workflows): bump Ubuntu from 20.04 to 22.04

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -23,7 +23,7 @@ jobs:
             os: linux
 
     name: nim-${{ matrix.nim }}-${{ matrix.os }}
-    runs-on: ${{ matrix.os == 'linux' && 'ubuntu-20.04' || (matrix.os == 'macOS' && 'macos-10.15' || 'windows-2019') }}
+    runs-on: ${{ matrix.os == 'linux' && 'ubuntu-22.04' || (matrix.os == 'macOS' && 'macos-10.15' || 'windows-2019') }}
 
     steps:
       - name: Checkout exercism/nim

--- a/.github/workflows/uuids.yml
+++ b/.github/workflows/uuids.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   check_uuids:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The `ubuntu-22.04` label was announced as stable in GitHub Actions on 2022-08-09 (see the [stable announcement](https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/) and [beta announcement](https://github.blog/changelog/2022-05-10-github-actions-beta-of-ubuntu-22-04-for-github-hosted-runners-is-now-available/)). But note that the `ubuntu-latest` label [currently uses Ubuntu 20.04](https://github.com/actions/runner-images/blob/2b48347ec3e3/README.md#available-images).

This commit also bumps GCC [from](https://github.com/actions/runner-images/blob/2b48347ec3e3/images/linux/Ubuntu2004-Readme.md) 9.4 [to][ubuntu-22.04] 11.2. See the GCC changelogs for [gcc-10](https://gcc.gnu.org/gcc-10/changes.html) and [gcc-11](https://gcc.gnu.org/gcc-11/changes.html) for more details.

The latest stable release of GCC [is GCC 12](https://gcc.gnu.org/releases.html), but it [isn't installed by default][ubuntu-22.04] with `ubuntu-22.04`.

Closes: #418

[ubuntu-22.04]: https://github.com/actions/runner-images/blob/2b48347ec3e3/images/linux/Ubuntu2204-Readme.md