### PR TITLE
.github(workflows): bump macOS from 10.15 to 12

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -23,7 +23,7 @@ jobs:
             os: linux
 
     name: nim-${{ matrix.nim }}-${{ matrix.os }}
-    runs-on: ${{ matrix.os == 'linux' && 'ubuntu-22.04' || (matrix.os == 'macOS' && 'macos-10.15' || 'windows-2019') }}
+    runs-on: ${{ matrix.os == 'linux' && 'ubuntu-22.04' || (matrix.os == 'macOS' && 'macos-12' || 'windows-2019') }}
 
     steps:
       - name: Checkout exercism/nim


### PR DESCRIPTION
The `macos-12` label has been available as a public beta [since 2022-04-25](https://github.blog/changelog/2022-04-25-github-actions-public-beta-of-macos-12-for-github-hosted-runners-is-now-available/) and exited beta [on 2022-06-13](https://github.blog/changelog/2022-06-13-github-actions-macos-12-for-github-hosted-runners-is-now-generally-available/). But note that the `macos-latest` label [currently still uses macOS 11](https://github.com/actions/runner-images/blob/891a05dfdbec/README.md#available-images).

This commit also bumps Clang [from](https://github.com/actions/runner-images/blob/891a05dfdbec/images/macos/macos-10.15-Readme.md) 12.0.0 [to](https://github.com/actions/runner-images/blob/891a05dfdbec/images/macos/macos-12-Readme.md) 14.0.0.

The [latest release of LLVM is 15.03](https://releases.llvm.org).

Closes: #419