### PR TITLE
.github(workflows): bump Windows from 2019 to 2022

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -23,7 +23,7 @@ jobs:
             os: linux
 
     name: nim-${{ matrix.nim }}-${{ matrix.os }}
-    runs-on: ${{ matrix.os == 'linux' && 'ubuntu-22.04' || (matrix.os == 'macOS' && 'macos-12' || 'windows-2019') }}
+    runs-on: ${{ matrix.os == 'linux' && 'ubuntu-22.04' || (matrix.os == 'macOS' && 'macos-12' || 'windows-2022') }}
 
     steps:
       - name: Checkout exercism/nim


### PR DESCRIPTION
The `windows-latest` label has run jobs on Windows Server 2022 [since](https://github.blog/changelog/2022-01-11-github-actions-jobs-running-on-windows-latest-are-now-running-on-windows-server-2022/)
2022-01-11 (see also the [current images](https://github.com/actions/runner-images/blob/891a05dfdbec/README.md#available-images)).

This also bumps the Mingw-w64 version [from](https://github.com/actions/runner-images/blob/891a05dfdbec/images/win/Windows2019-Readme.md) 8.1.0 [to](https://github.com/actions/runner-images/blob/891a05dfdbec/images/win/Windows2022-Readme.md) 11.2.0 (it looks like it's installed in the runners [here](https://github.com/actions/runner-images/blob/891a05dfdbec/images/win/scripts/Installers/Install-Mingw64.ps1#L7)).
The latest release of Mingw-w64 is [12.2.0](https://community.chocolatey.org/packages/mingw#versionhistory) (2022-10-16).

Closes: #420