### PR TITLE
.github(workflows): pin `actions/checkout` to 3.1.0

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout exercism/nim
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
       - name: Set BRANCH environmental variable
         shell: bash # Changes the default shell on Windows.

--- a/.github/workflows/uuids.yml
+++ b/.github/workflows/uuids.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
     - name: Get the version of the latest stable Nim
       run: |


### PR DESCRIPTION
See: https://github.com/actions/checkout/releases/

Refs: https://github.com/exercism/nim/issues/421