### PR TITLE
.github(workflows): pin `actions/cache` to 3.0.11

### DIFF
--- a/.github/workflows/uuids.yml
+++ b/.github/workflows/uuids.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Cache binary
       id: cache-uuids
-      uses: actions/cache@v3
+      uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
       with:
         path: _test/check_uuids
         key: check_uuids-${{ hashFiles('_test/check_uuids.nim') }}-${{ runner.os }}-nim${{ env.NIM_VERSION }}-gcc${{ env.GCC_VERSION }}-openssl${{ env.OPENSSL_VERSION }}


### PR DESCRIPTION
See: https://github.com/actions/cache/releases

Refs: https://github.com/exercism/nim/issues/421