### PR TITLE
.github(workflows): pin `jiro4989/setup-nim-action` to 1.3.63

### DIFF
--- a/.github/workflows/uuids.yml
+++ b/.github/workflows/uuids.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Install Nim
       if: steps.cache-uuids.outputs.cache-hit != 'true'
-      uses: jiro4989/setup-nim-action@v1
+      uses: jiro4989/setup-nim-action@85745da70ac91621f7c7e9fd353b7f1f3a1405c7
       with:
         nim-version: "${NIM_VERSION}"
 


### PR DESCRIPTION
See: https://github.com/jiro4989/setup-nim-action/releases

Closes: https://github.com/exercism/nim/issues/421