### PR TITLE
.github(workflows): bump Nim from 1.6.8 to 1.6.10

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -7,13 +7,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - nim: '1.6.8'
+          - nim: '1.6.10'
             os: linux
 
-          - nim: '1.6.8'
+          - nim: '1.6.10'
             os: macOS
 
-          - nim: '1.6.8'
+          - nim: '1.6.10'
             os: windows
 
           - nim: devel

--- a/.github/workflows/uuids.yml
+++ b/.github/workflows/uuids.yml
@@ -5,7 +5,7 @@ jobs:
   check_uuids:
     runs-on: ubuntu-22.04
     env:
-      NIM_VERSION: '1.6.8'
+      NIM_VERSION: '1.6.10'
 
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
See the [release blog post][blog-post] and changes since [1.6.8][changes].

[blog-post]: https://nim-lang.org/blog/2022/11/23/version-1610-released.html
[changes]: https://github.com/nim-lang/Nim/compare/v1.6.8...v1.6.10