### PR TITLE
.github(workflows): bump `iffy/install-nim` from 4.4.0 to 4.5.0

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install Nim (non-devel)
         if: matrix.nim != 'devel'
-        uses: iffy/install-nim@1ab2fcc1d8294b3956d5696f45cd470c9fe69466
+        uses: iffy/install-nim@560f0647083257e632182be888862d69eeb6f2c4
         with:
           version: "binary:${{ matrix.nim }}"
         env:

--- a/.github/workflows/uuids.yml
+++ b/.github/workflows/uuids.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Install Nim
       if: steps.cache-uuids.outputs.cache-hit != 'true'
-      uses: iffy/install-nim@1ab2fcc1d8294b3956d5696f45cd470c9fe69466
+      uses: iffy/install-nim@560f0647083257e632182be888862d69eeb6f2c4
       with:
         version: "binary:${{ env.NIM_VERSION }}"
       env:


### PR DESCRIPTION
Add support for Nim 1.6.10 (2022-11-23).

See the [changelog] and [commits] since our previously used version.

[changelog]: https://github.com/iffy/install-nim/blob/560f06470832/CHANGELOG.md
[commits]: https://github.com/iffy/install-nim/compare/1ab2fcc1d829...560f06470832

---

Double-checking that this PR bumped them all:

```console
$ git rev-parse --short HEAD
7080ae6
$ git grep --break --heading 'iffy'
github/workflows/exercises.yml
41:        uses: iffy/install-nim@560f0647083257e632182be888862d69eeb6f2c4

.github/workflows/uuids.yml
27:      uses: iffy/install-nim@560f0647083257e632182be888862d69eeb6f2c4
```