### PR TITLE
.github, docs: bump minimum Nim version from 1.0.0 to 1.6.0

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -19,7 +19,7 @@ jobs:
           - nim: devel
             os: linux
 
-          - nim: '1.0.10'
+          - nim: '1.6.0'
             os: linux
 
     name: nim-${{ matrix.nim }}-${{ matrix.os }}

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,4 +2,4 @@
 
 Please refer to the official [Install Nim](https://nim-lang.org/install.html) page for up-to-date installation instructions.
 
-Exercism supports Nim 1.0.0 and later versions.
+Exercism supports Nim 1.6.0 and later versions.


### PR DESCRIPTION
Supporting Nim 1.0.0, [which is more than 3 years old][1], is becoming more of a burden. Let's raise the minimum supported version to 1.6.0, which is [about 15 months old][2].

Nim 2.0 is [expected in early 2023][3].

[1]: https://nim-lang.org/blog/2019/09/23/version-100-released.html
[2]: https://nim-lang.org/blog/2021/10/19/version-160-released.html
[3]: https://nim-lang.org/blog/2022/12/21/version-20-rc.html

Refs: #343
Refs: #456
Refs: #458
Closes: #457