### PR TITLE
exercises(resistor-color-trio): sync tests and docs

### DIFF
--- a/exercises/practice/resistor-color-trio/.docs/instructions.md
+++ b/exercises/practice/resistor-color-trio/.docs/instructions.md
@@ -46,9 +46,11 @@ So an input of `"orange", "orange", "black"` should return:
 
 > "33 ohms"
 
-When we get more than a thousand ohms, we say "kiloohms".
-That's similar to saying "kilometer" for 1000 meters, and "kilograms" for 1000 grams.
+When we get to larger resistors, a [metric prefix][metric-prefix] is used to indicate a larger magnitude of ohms, such as "kiloohms".
+That is similar to saying "2 kilometers" instead of "2000 meters", or "2 kilograms" for "2000 grams".
 
-So an input of `"orange", "orange", "orange"` should return:
+For example, an input of `"orange", "orange", "orange"` should return:
 
 > "33 kiloohms"
+
+[metric-prefix]: https://en.wikipedia.org/wiki/Metric_prefix

--- a/exercises/practice/resistor-color-trio/.meta/tests.toml
+++ b/exercises/practice/resistor-color-trio/.meta/tests.toml
@@ -23,3 +23,19 @@ description = "Green and brown and orange"
 
 [f5d37ef9-1919-4719-a90d-a33c5a6934c9]
 description = "Yellow and violet and yellow"
+
+[5f6404a7-5bb3-4283-877d-3d39bcc33854]
+description = "Blue and violet and blue"
+
+[7d3a6ab8-e40e-46c3-98b1-91639fff2344]
+description = "Minimum possible value"
+
+[ca0aa0ac-3825-42de-9f07-dac68cc580fd]
+description = "Maximum possible value"
+
+[0061a76c-903a-4714-8ce2-f26ce23b0e09]
+description = "First two colors make an invalid octal number"
+
+[30872c92-f567-4b69-a105-8455611c10c4]
+description = "Ignore extra colors"
+include = false

--- a/exercises/practice/resistor-color-trio/test_resistor_color_trio.nim
+++ b/exercises/practice/resistor-color-trio/test_resistor_color_trio.nim
@@ -16,3 +16,15 @@ suite "Resistor Color Trio":
 
   test "yellow and violet and yellow":
     check label([Yellow, Violet, Yellow]) == (470, "kiloohms")
+
+  test "blue and violet and blue":
+    check label([Blue, Violet, Blue]) == (67, "megaohms")
+
+  test "minimum possible value":
+    check label([Black, Black, Black]) == (0, "ohms")
+
+  test "maximum possible value":
+    check label([White, White, White]) == (99, "gigaohms")
+
+  test "first two colors make an invalid octal number":
+    check label([Black, Grey, Black]) == (8, "ohms")


### PR DESCRIPTION
Do not implement the last new test, which uses 4 colors as an input.

Upstream: https://github.com/exercism/problem-specifications/commit/cb7eab5785c11454cf4cf3ec6124145a84582678