### PR TITLE
docs: unify instructions for running exercise tests

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -6,4 +6,4 @@ To compile and run the tests, just run the following in your exercise directory:
 nim r test_exercise_name.nim
 ```
 
-(Replace `exercise_name` with the name of the exercise).
+Replace `exercise_name` with the name of the exercise (e.g. `all_your_base`).

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -3,7 +3,7 @@
 To compile and run the tests, just run the following in your exercise directory:
 
 ```shell
-nim r test_<snake-case-exercise>.nim
+nim r test_exercise_name.nim
 ```
 
-Replace `<snake-case-exercise>` with the actual exercise name in snake case (e.g. `all_your_base`).
+Replace `exercise_name` with the name of the exercise (e.g. `all_your_base`).


### PR DESCRIPTION
It was particularly unclear for `<snake-case-exercise>` to be delimited with hyphens, rather than underscores.

Closes: #467