### PR TITLE
exercises(clock): remove support for older Nim

### DIFF
--- a/exercises/practice/clock/.meta/example.nim
+++ b/exercises/practice/clock/.meta/example.nim
@@ -1,14 +1,5 @@
 import std/[math, strformat]
 
-# `euclMod` was added to `std/math` in Nim 1.6.0.
-# Define `euclMod` ourselves when we are compiling with an earlier Nim version.
-when not compiles(euclMod(3, 2)):
-  func euclMod*[T: SomeNumber](x, y: T): T =
-    ## Returns euclidean modulo of `x` by `y` (returning a non-negative number).
-    result = x mod y
-    if result < 0:
-      result += abs(y)
-
 type
   Clock* = object
     hour*: range[0..23]


### PR DESCRIPTION
With commit 1ac18dfba497 the Nim track now officially only supports Nim 1.6.0 or newer. CI does not run using any older version, so we can remove support for older Nim from the example solution. This isn't user-facing.