### PR TITLE
exercises(gigasecond): use `dateTime`, not deprecated `initDateTime`

### DIFF
--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,0 +1,3 @@
+# Hints
+
+This exercise requires Nim 1.6.0 (released 2021-10-19) or later.

--- a/exercises/practice/gigasecond/test_gigasecond.nim
+++ b/exercises/practice/gigasecond/test_gigasecond.nim
@@ -3,26 +3,26 @@ import gigasecond
 
 suite "Gigasecond":
   test "date only specification of time":
-    let moment   = initDateTime(25, mApr, 2011, 0, 0, 0, utc())
-    let expected = initDateTime(1, mJan, 2043, 1, 46, 40, utc())
+    let moment   = dateTime(2011, mApr, 25, 0, 0, 0, zone = utc())
+    let expected = dateTime(2043, mJan, 1, 1, 46, 40, zone = utc())
     check addGigasecond(moment) == expected
 
   test "second test for date only specification of time":
-    let moment   = initDateTime(13, mJun, 1977, 0, 0, 0, utc())
-    let expected = initDateTime(19, mFeb, 2009, 1, 46, 40, utc())
+    let moment   = dateTime(1977, mJun, 13, 0, 0, 0, zone = utc())
+    let expected = dateTime(2009, mFeb, 19, 1, 46, 40, zone = utc())
     check addGigasecond(moment) == expected
 
   test "third test for date only specification of time":
-    let moment   = initDateTime(19, mJul, 1959, 0, 0, 0, utc())
-    let expected = initDateTime(27, mMar, 1991, 1, 46, 40, utc())
+    let moment   = dateTime(1959, mJul, 19, 0, 0, 0, zone = utc())
+    let expected = dateTime(1991, mMar, 27, 1, 46, 40, zone = utc())
     check addGigasecond(moment) == expected
 
   test "full time specified":
-    let moment   = initDateTime(24, mJan, 2015, 22, 0, 0, utc())
-    let expected = initDateTime(2, mOct, 2046, 23, 46, 40, utc())
+    let moment   = dateTime(2015, mJan, 24, 22, 0, 0, zone = utc())
+    let expected = dateTime(2046, mOct, 2, 23, 46, 40, zone = utc())
     check addGigasecond(moment) == expected
 
   test "full time with day roll-over":
-    let moment   = initDateTime(24, mJan, 2015, 23, 59, 59, utc())
-    let expected = initDateTime(3, mOct, 2046, 1, 46, 39, utc())
+    let moment   = dateTime(2015, mJan, 24, 23, 59, 59, zone = utc())
+    let expected = dateTime(2046, mOct, 3, 1, 46, 39, zone = utc())
     check addGigasecond(moment) == expected


### PR DESCRIPTION
Before this commit, compiling the tests for `gigasecond` with Nim 1.6.0 or newer would produce 10 deprecation warnings, starting with:

```text
test_gigasecond.nim(4, 7) template/generic instantiation of `suite` from here
test_gigasecond.nim(5, 8) template/generic instantiation of `test` from here
test_gigasecond.nim(6, 20) Warning: use `dateTime`; initDateTime is deprecated [Deprecated]
[...]
```

This is because Nim 1.6.0 added a `dateTime` proc that uses the ISO 8601 order, and deprecated the `initDateTime` proc (see [here][1] and [here][2].

With commit 1ac18dfba497 the Nim track now officially only supports Nim 1.6.0 or newer. So let's stop supporting older Nim in this exercise.

[1]: https://github.com/nim-lang/Nim/blob/1e52423774e8/changelogs/changelog_1_6_0.md
[2]: https://github.com/nim-lang/Nim/commit/4c1202972abd

Closes: #343