### PR TITLE
exercises(twelve-days): remove support for older Nim

### DIFF
--- a/exercises/practice/twelve-days/.meta/example.nim
+++ b/exercises/practice/twelve-days/.meta/example.nim
@@ -40,8 +40,7 @@ func generateVerses: tuple[song: string, indices: DayArray[int]] =
 
 const (song, indices) = generateVerses() # Generate the lyrics at compile-time.
 
-func recite*(start: DayRange, stop: DayRange = 1): string =
-  let stop = if stop == 1: start else: stop # Workaround for Nim bug #11274.
+func recite*(start: DayRange, stop = start): string =
   let firstChar = indices[start]
   let lastChar = if stop == 12: song.high - 2 else: indices[stop + 1] - 3
   result = song[firstChar .. lastChar] # Excludes the final two newlines.


### PR DESCRIPTION
We no longer need this workaround. The [bug][1] fix is [included in Nim 1.4.0][2], and with commit 1ac18dfba497 the Nim track now officially only supports Nim 1.6.0 or newer.

This PR is not user-facing - it only affects the example solution.

[1]: https://www.github.com/nim-lang/Nim/issues/11274
[2]: https://github.com/nim-lang/Nim/commit/35ff17410f30
