### PR TITLE
.github: enable `configlet fmt` in CI

### DIFF
--- a/.github/workflows/configlet.yml
+++ b/.github/workflows/configlet.yml
@@ -13,3 +13,5 @@ permissions:
 jobs:
   configlet:
     uses: exercism/github-actions/.github/workflows/configlet.yml@main
+    with:
+      fmt: true


### PR DESCRIPTION
Other tracks that do this at the time of writing:

- [csharp](https://github.com/exercism/csharp/blob/dd9bdcb69c3ad15ef6cb6cdc43b6c6e80d90fac9/.github/workflows/configlet.yml#L17)
- [elixir](https://github.com/exercism/elixir/blob/52dbe60849ee4e3c5aba54064c9b3e34e6c25f81/.github/workflows/configlet.yml#L17)
- [elm](https://github.com/exercism/elm/blob/5ebf3d93f48398cdfa265c3db595bedfba304267/.github/workflows/configlet.yml#L17)
- [fsharp](https://github.com/exercism/fsharp/blob/c4942481578628a4d78165536988983c5643b0f7/.github/workflows/configlet.yml#L17)
- [javascript](https://github.com/exercism/javascript/blob/2381f3af2c3c81147488bc1e75fd69aa47ca4f19/.github/workflows/configlet.yml#L17)
- [tcl](https://github.com/exercism/tcl/blob/ff61ff10498f197d1bfba5aa321669e629151842/.github/workflows/configlet.yml#L17)
- [unison](https://github.com/exercism/unison/blob/7e617df131c1e89aba2e93969f431d9e6497305d/.github/workflows/configlet.yml#L17)