### PR TITLE
docs: use one sentence per line

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Please see the [contributing guide](https://exercism.org/docs/building/tracks).
 
 ## Testing
 
-The file [`_test/check_exercises.nim`](https://github.com/exercism/nim/blob/main/_test/check_exercises.nim) checks that the example solution for every implemented exercise passes that exercise's test suite. This repo runs that file during CI, and you can also run it on your own machine.
+The file [`_test/check_exercises.nim`](https://github.com/exercism/nim/blob/main/_test/check_exercises.nim) checks that the example solution for every implemented exercise passes that exercise's test suite.
+This repo runs that file during CI, and you can also run it on your own machine.
 
 To test all the exercises, run:
 
@@ -22,8 +23,11 @@ To test a selection of exercises, run:
 nim r check_exercises.nim [exercise-name] [...]
 ```
 
-This finds all the relevant tests, processes them into a new directory for testing, and runs them. For more information, please read the documentation comments in [`_test/check_exercises.nim`](https://github.com/exercism/nim/blob/main/_test/check_exercises.nim) or run `check_exercises` with the `--help` option.
+This finds all the relevant tests, processes them into a new directory for testing, and runs them.
+For more information, please read the documentation comments in [`_test/check_exercises.nim`](https://github.com/exercism/nim/blob/main/_test/check_exercises.nim) or run `check_exercises` with the `--help` option.
 
 ### Nim icon
 
-The Nim logo is assumed to be owned by Andreas Rumpf. It appears to be released under the MIT license, along with the Nim codebase. We've adapted the official Nim logo by changing the colors, which we believe falls under fair use.
+The Nim logo is assumed to be owned by Andreas Rumpf.
+It appears to be released under the MIT license, along with the Nim codebase.
+We've adapted the official Nim logo by changing the colors, which we believe falls under fair use.

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,9 +1,15 @@
 # About
 
-Nim is a general-purpose language designed and developed by Andreas Rumpf and first appearing in 2008. Designed to be efficient, expressive, and elegant. Nim is statically typed and compiled but lets you write elegant code that runs efficiently. Nim lets you target many platforms by compiling code to C, C++, JavaScript, or Objective-C. Nim syntax is similar to Python and shares many of Python's characteristics but draws inspiration from a number of languages, such as C, C++, C#, Lisp, Ada, Go, Oberon, and others.
+Nim is a general-purpose language designed and developed by Andreas Rumpf and first appearing in 2008.
+Designed to be efficient, expressive, and elegant.
+Nim is statically typed and compiled but lets you write elegant code that runs efficiently.
+Nim lets you target many platforms by compiling code to C, C++, JavaScript, or Objective-C.
+Nim syntax is similar to Python and shares many of Python's characteristics but draws inspiration from a number of languages, such as C, C++, C#, Lisp, Ada, Go, Oberon, and others.
 
 As Nim is a general-purpose language it can be used in various places but has been filling a real niche in the area of Game development and Systems Programming including Embedded systems.
 
 Nim gives you a lot of the convenience you find in Python and other languages, like easy to read syntax, a package management system for using new libraries in your projects, and user-friendly tracebacks for debugging errors.
 
-Nim gives you the speed and portability of C, but with a high-performance garbage-collector and elegant syntax that makes the language very approachable to new people. Nim also gives you control, letting you change the garbage-collector or turn it off completely giving you the option to manage memory yourself. You have a variety of programming paradigms and abstraction layers with Nim.
+Nim gives you the speed and portability of C, but with a high-performance garbage-collector and elegant syntax that makes the language very approachable to new people.
+Nim also gives you control, letting you change the garbage-collector or turn it off completely giving you the option to manage memory yourself.
+You have a variety of programming paradigms and abstraction layers with Nim.

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,8 +1,10 @@
 # Learning
 
-Exercism provides exercises and feedback but can be difficult to jump into for those learning Nim for the first time. These resources can help you get started:
+Exercism provides exercises and feedback but can be difficult to jump into for those learning Nim for the first time.
+These resources can help you get started:
 
-[Nim in Action](https://book.picheta.me/) is a great book, I would say that this is one of the best resources for learning Nim and what you can do with the language. I highly recommend this book as a good starting point.
+[Nim in Action](https://book.picheta.me/) is a great book, I would say that this is one of the best resources for learning Nim and what you can do with the language.
+I highly recommend this book as a good starting point.
 
 The [Standard Library Documentation](https://nim-lang.org/docs/lib.html) is a great resource for looking at items that are part of the Nim's standard library and how to use them.
 

--- a/exercises/concept/lasagna/.docs/instructions.md
+++ b/exercises/concept/lasagna/.docs/instructions.md
@@ -6,7 +6,9 @@ You have five tasks, all related to the time spent cooking the lasagna.
 
 ## 1. Define the expected oven time in minutes
 
-Define the `expectedMinutesInOven` immutable variable that returns how many minutes the lasagna should be in the oven. It must be exported. According to the cooking book, the expected oven time in minutes is 40:
+Define the `expectedMinutesInOven` immutable variable that returns how many minutes the lasagna should be in the oven.
+It must be exported.
+According to the cooking book, the expected oven time in minutes is 40:
 
 ```nim
 nim> expectedMinutesInOven
@@ -33,7 +35,8 @@ nim> preparationTimeInMinutes(2)
 
 ## 4. Calculate the total working time in minutes
 
-Implement the `totalTimeInMinutes` procedure that takes two parameters: the `numberOfLayers` parameter is the number of layers you added to the lasagna, and the `actualMinutesInOven` parameter is the number of minutes the lasagna has been in the oven. The procedure should return how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
+Implement the `totalTimeInMinutes` procedure that takes two parameters: the `numberOfLayers` parameter is the number of layers you added to the lasagna, and the `actualMinutesInOven` parameter is the number of minutes the lasagna has been in the oven.
+The procedure should return how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
 
 ```nim
 nim> totalTimeInMinutes(3, 20)

--- a/reference/implementing-a-concept-exercise.md
+++ b/reference/implementing-a-concept-exercise.md
@@ -1,5 +1,6 @@
 # How to implement a Nim concept exercise
 
-TODO: describe how to implement a concept exercise for the Nim track. For inspiration, check out the [C# version of this file][csharp-implementing].
+TODO: describe how to implement a concept exercise for the Nim track.
+For inspiration, check out the [C# version of this file][csharp-implementing].
 
 [csharp-implementing]: https://github.com/exercism/v3/blob/main/csharp/reference/implementing-a-concept-exercise.md


### PR DESCRIPTION
Comply with the [Exercism Markdown Specification][1]:

>Paragraphs should be laid at using one sentence per line.
>The [Ascii Doctor docs][2] explain the logic of this clearly.
>
>For example, a single paragraph should be laid out as follows:
>
>```
>Exercism has been designed, engineered and built by thousands of very talented individuals.
>Nearly everything with Exercism has been debated, discussed and rewritten many times.
>Exercism is a very intentional product - things are there because they've been designed to be there, and things are often left out because they've been designed to be left out.

[1]: https://github.com/exercism/docs/blob/f02a3bcda987/building/markdown/markdown.md#one-sentence-per-line
[2]: https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line

Closes: #423