### PR TITLE
exercises(darts): use separate parameters, not tuple

### DIFF
--- a/exercises/practice/darts/.meta/example.nim
+++ b/exercises/practice/darts/.meta/example.nim
@@ -1,7 +1,7 @@
 import math
 
-func score*(p: tuple[x, y: float]): int =
-  let r = hypot(p.x, p.y)
+func score*(x, y: float): int =
+  let r = hypot(x, y)
   if r <= 1:
     10
   elif r <= 5:

--- a/exercises/practice/darts/test_darts.nim
+++ b/exercises/practice/darts/test_darts.nim
@@ -3,40 +3,40 @@ import darts
 
 suite "Darts":
   test "missed target":
-    check score((-9.0, 9.0)) == 0
+    check score(-9.0, 9.0) == 0
 
   test "on the outer circle":
-    check score((0.0, 10.0)) == 1
+    check score(0.0, 10.0) == 1
 
   test "on the middle circle":
-    check score((-5.0, 0.0)) == 5
+    check score(-5.0, 0.0) == 5
 
   test "on the inner circle":
-    check score((0.0, -1.0)) == 10
+    check score(0.0, -1.0) == 10
 
   test "exactly on centre":
-    check score((0.0, 0.0)) == 10
+    check score(0.0, 0.0) == 10
 
   test "near the centre":
-    check score((-0.1, -0.1)) == 10
+    check score(-0.1, -0.1) == 10
 
   test "just within the inner circle":
-    check score((0.7, 0.7)) == 10
+    check score(0.7, 0.7) == 10
 
   test "just outside the inner circle":
-    check score((0.8, -0.8)) == 5
+    check score(0.8, -0.8) == 5
 
   test "just within the middle circle":
-    check score((-3.5, 3.5)) == 5
+    check score(-3.5, 3.5) == 5
 
   test "just outside the middle circle":
-    check score((-3.6, -3.6)) == 1
+    check score(-3.6, -3.6) == 1
 
   test "just within the outer circle":
-    check score((-7.0, 7.0)) == 1
+    check score(-7.0, 7.0) == 1
 
   test "just outside the outer circle":
-    check score((7.1, -7.1)) == 0
+    check score(7.1, -7.1) == 0
 
   test "asymmetric position between the inner and middle circles":
-    check score((0.5, -4.0)) == 5
+    check score(0.5, -4.0) == 5


### PR DESCRIPTION
I think that the procedure in this exercise should take either two separate parameters, or an object (named e.g. `Coord` or `Point`). Using a tuple parameter feels like the worst of both worlds.

Let's go with two parameters for now. A common way to solve this exercise is with `hypot`, which also takes separate parameters.

---

The alternative would be like:

```nim
type
  Point* = object
    x*: float
    y*: float
```

where the tests can have one of the below formats

```nim
check initPoint(-9.0, 9.0).score() == 0
```

```nim
check Point.init(-9.0, 9.0).score() == 0
```

```nim
check Point(x: -9.0, y: 9.0).score() == 0
```