### PR TITLE
exercises: examples: prefix stdlib imports with `std/`

### DIFF
--- a/exercises/practice/acronym/.meta/example.nim
+++ b/exercises/practice/acronym/.meta/example.nim
@@ -1,4 +1,4 @@
-import re, sequtils, strutils
+import std/[re, sequtils, strutils]
 
 proc abbreviate*(phrase: string): string =
   let words = phrase.findAll(re"[A-Z]+['a-z]*|['a-z]+")

--- a/exercises/practice/all-your-base/.meta/example.nim
+++ b/exercises/practice/all-your-base/.meta/example.nim
@@ -1,4 +1,4 @@
-import algorithm, math
+import std/[algorithm, math]
 
 func convert*(digits: openArray[int], fromBase: int, toBase: int): seq[int] =
   if fromBase < 2:

--- a/exercises/practice/anagram/.meta/example.nim
+++ b/exercises/practice/anagram/.meta/example.nim
@@ -1,4 +1,4 @@
-import algorithm, sequtils, strutils
+import std/[algorithm, sequtils, strutils]
 
 type TAnagram = tuple
   word: string

--- a/exercises/practice/armstrong-numbers/.meta/example.nim
+++ b/exercises/practice/armstrong-numbers/.meta/example.nim
@@ -1,4 +1,4 @@
-import math, strutils
+import std/[math, strutils]
 
 proc isArmstrongNumber*(input: int): bool =
   let stringNumber = $input

--- a/exercises/practice/atbash-cipher/.meta/example.nim
+++ b/exercises/practice/atbash-cipher/.meta/example.nim
@@ -1,4 +1,4 @@
-import sequtils, strutils
+import std/[sequtils, strutils]
 
 const
   Plain = "abcdefghijklmnopqrstuvwxyz"

--- a/exercises/practice/binary/.meta/example.nim
+++ b/exercises/practice/binary/.meta/example.nim
@@ -1,5 +1,5 @@
-from algorithm import reversed
-from strutils import allCharsInSet
+from std/algorithm import reversed
+from std/strutils import allCharsInSet
 
 proc binary*(input: string): int {.raises: [ValueError]} =
   if not input.allCharsInSet({'0', '1'}):

--- a/exercises/practice/bob/.meta/example.nim
+++ b/exercises/practice/bob/.meta/example.nim
@@ -1,5 +1,5 @@
-from strutils import endsWith, strip
-from unicode import isLower, isUpper, isWhiteSpace, runes
+from std/strutils import endsWith, strip
+from std/unicode import isLower, isUpper, isWhiteSpace, runes
 
 proc isSilence(s: string): bool =
   for r in runes(s):

--- a/exercises/practice/crypto-square/.meta/example.nim
+++ b/exercises/practice/crypto-square/.meta/example.nim
@@ -1,4 +1,4 @@
-import math, strutils
+import std/[math, strutils]
 
 func encrypt*(s: string): string =
   var normalized = newStringOfCap(s.len)

--- a/exercises/practice/darts/.meta/example.nim
+++ b/exercises/practice/darts/.meta/example.nim
@@ -1,4 +1,4 @@
-import math
+import std/math
 
 func score*(p: tuple[x, y: float]): int =
   let r = hypot(p.x, p.y)

--- a/exercises/practice/diamond/.meta/example.nim
+++ b/exercises/practice/diamond/.meta/example.nim
@@ -1,4 +1,4 @@
-import strutils
+import std/strutils
 
 func toDiamond(c: char): seq[string] =
   let rowLen = 2 * (c.ord - 'A'.ord) + 1

--- a/exercises/practice/diffie-hellman/.meta/example.nim
+++ b/exercises/practice/diffie-hellman/.meta/example.nim
@@ -1,4 +1,4 @@
-import random
+import std/random
 
 randomize()
 

--- a/exercises/practice/etl/.meta/example.nim
+++ b/exercises/practice/etl/.meta/example.nim
@@ -1,4 +1,4 @@
-import strutils, tables
+import std/[strutils, tables]
 
 func transform*(t: Table[int, seq[char]]): Table[char, int] =
   result = initTable[char, int]()

--- a/exercises/practice/gigasecond/.meta/example.nim
+++ b/exercises/practice/gigasecond/.meta/example.nim
@@ -1,4 +1,4 @@
-import times
+import std/times
 
 proc addGigasecond*(date: DateTime): DateTime =
   date + initTimeInterval(seconds = 1_000_000_000)

--- a/exercises/practice/hamming/.meta/example.nim
+++ b/exercises/practice/hamming/.meta/example.nim
@@ -1,4 +1,4 @@
-import sequtils
+import std/sequtils
 
 proc isDifferent(pair: tuple[a, b: char]): bool = pair.a != pair.b
 

--- a/exercises/practice/high-scores/.meta/example.nim
+++ b/exercises/practice/high-scores/.meta/example.nim
@@ -1,4 +1,4 @@
-import algorithm
+import std/algorithm
 
 func latest*(scores: openArray[int]): int =
   scores[^1]

--- a/exercises/practice/isogram/.meta/example.nim
+++ b/exercises/practice/isogram/.meta/example.nim
@@ -1,4 +1,4 @@
-import sequtils, sets, strutils
+import std/[sequtils, sets, strutils]
 
 proc isIsogram*(phrase: string): bool =
   let charactersLower = phrase.filterIt(it.isAlphaAscii()).mapIt(it.toLowerAscii)

--- a/exercises/practice/matching-brackets/.meta/example.nim
+++ b/exercises/practice/matching-brackets/.meta/example.nim
@@ -1,4 +1,4 @@
-import deques, sequtils, tables
+import std/[deques, sequtils, tables]
 
 const
   lookupTable = {'(': ')', '{': '}', '[': ']'}.toTable

--- a/exercises/practice/matrix/.meta/example.nim
+++ b/exercises/practice/matrix/.meta/example.nim
@@ -1,4 +1,4 @@
-import strutils
+import std/strutils
 
 func matrix(s: string): seq[seq[int]] =
   for line in s.splitLines:

--- a/exercises/practice/meetup/.meta/example.nim
+++ b/exercises/practice/meetup/.meta/example.nim
@@ -1,4 +1,4 @@
-import strformat, times
+import std/[strformat, times]
 
 type Schedule* = enum
   Teenth, First, Second, Third, Fourth, Last

--- a/exercises/practice/nth-prime/.meta/example.nim
+++ b/exercises/practice/nth-prime/.meta/example.nim
@@ -1,4 +1,4 @@
-import math
+import std/math
 
 proc isPrime(n: int): bool =
   if n <= 1:

--- a/exercises/practice/nucleotide-count/.meta/example.nim
+++ b/exercises/practice/nucleotide-count/.meta/example.nim
@@ -1,4 +1,4 @@
-import tables
+import std/tables
 
 func countDna*(s: string): CountTable[char] =
   result = s.toCountTable()

--- a/exercises/practice/pangram/.meta/example.nim
+++ b/exercises/practice/pangram/.meta/example.nim
@@ -1,4 +1,4 @@
-import strutils
+import std/strutils
 
 const
   asciiLowercase = {'a'..'z'}

--- a/exercises/practice/perfect-numbers/.meta/example.nim
+++ b/exercises/practice/perfect-numbers/.meta/example.nim
@@ -1,4 +1,4 @@
-import math
+import std/math
 
 type Classification* = enum
   Perfect, Deficient, Abundant

--- a/exercises/practice/protein-translation/.meta/example.nim
+++ b/exercises/practice/protein-translation/.meta/example.nim
@@ -1,4 +1,4 @@
-import tables
+import std/tables
 
 const codonToAminoAcid = {
   "AUG": "Methionine",

--- a/exercises/practice/proverb/.meta/example.nim
+++ b/exercises/practice/proverb/.meta/example.nim
@@ -1,4 +1,4 @@
-import strformat
+import std/strformat
 
 func recite*(s: openArray[string]): string =
   if s.len == 0:

--- a/exercises/practice/raindrops/.meta/example.nim
+++ b/exercises/practice/raindrops/.meta/example.nim
@@ -1,4 +1,4 @@
-import strutils
+import std/strutils
 
 proc convert*(sound: int): string =
   var raindrops = ""

--- a/exercises/practice/resistor-color-trio/.meta/example.nim
+++ b/exercises/practice/resistor-color-trio/.meta/example.nim
@@ -1,4 +1,4 @@
-import math
+import std/math
 
 type
   ResistorColor* = enum

--- a/exercises/practice/robot-name/.meta/example.nim
+++ b/exercises/practice/robot-name/.meta/example.nim
@@ -1,4 +1,4 @@
-import random
+import std/random
 
 type
   Name = array[5, char]

--- a/exercises/practice/run-length-encoding/.meta/example.nim
+++ b/exercises/practice/run-length-encoding/.meta/example.nim
@@ -1,4 +1,4 @@
-import re, sequtils, strutils
+import std/[re, sequtils, strutils]
 
 proc encode*(input: string): string =
   input.findAll(re"([\w\s])\1*").map(proc(i: string): string =

--- a/exercises/practice/saddle-points/.meta/example.nim
+++ b/exercises/practice/saddle-points/.meta/example.nim
@@ -1,4 +1,4 @@
-import sequtils
+import std/sequtils
 
 func saddlePoints*(matrix: seq[seq[int]]): seq[tuple[r, c: int]] =
   if matrix.len == 0:

--- a/exercises/practice/scale-generator/.meta/example.nim
+++ b/exercises/practice/scale-generator/.meta/example.nim
@@ -1,4 +1,4 @@
-import sets, strutils, tables
+import std/[sets, strutils, tables]
 
 const
   chromaticSharps = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]

--- a/exercises/practice/scrabble-score/.meta/example.nim
+++ b/exercises/practice/scrabble-score/.meta/example.nim
@@ -1,4 +1,4 @@
-import math, sequtils, strutils, tables
+import std/[math, sequtils, strutils, tables]
 
 let
   points = {

--- a/exercises/practice/secret-handshake/.meta/example.nim
+++ b/exercises/practice/secret-handshake/.meta/example.nim
@@ -1,4 +1,4 @@
-import algorithm
+import std/algorithm
 
 const
   signals = [

--- a/exercises/practice/sieve/.meta/example.nim
+++ b/exercises/practice/sieve/.meta/example.nim
@@ -1,4 +1,4 @@
-import math
+import std/math
 
 func eratosthenes(n: int): seq[bool] =
   result = newSeq[bool](n+1)

--- a/exercises/practice/sum-of-multiples/.meta/example.nim
+++ b/exercises/practice/sum-of-multiples/.meta/example.nim
@@ -1,4 +1,4 @@
-import sequtils
+import std/sequtils
 
 proc sum*(limit: int, factors: seq[int]): int =
   for num in 0..<limit:

--- a/exercises/practice/triangle/.meta/example.nim
+++ b/exercises/practice/triangle/.meta/example.nim
@@ -1,4 +1,4 @@
-import sequtils
+import std/sequtils
 
 proc valid(a, b, c: int): bool =
   let greatThenZero = all([a, b, c], proc (x: int): bool = return x > 0)

--- a/exercises/practice/twelve-days/.meta/example.nim
+++ b/exercises/practice/twelve-days/.meta/example.nim
@@ -1,4 +1,4 @@
-import strformat
+import std/strformat
 
 type
   DayRange = range[1..12]

--- a/exercises/practice/word-count/.meta/example.nim
+++ b/exercises/practice/word-count/.meta/example.nim
@@ -1,4 +1,4 @@
-import re, strutils, tables
+import std/[re, strutils, tables]
 
 iterator words(sentence: string): string =
   for word in sentence.findAll(re"[a-zA-Z0-9]+(['][a-z]+)?"):

--- a/exercises/practice/yacht/.meta/example.nim
+++ b/exercises/practice/yacht/.meta/example.nim
@@ -1,4 +1,4 @@
-import math
+import std/math
 
 type Category* = enum
   Ones = 1, Twos, Threes, Fours, Fives, Sixes,


### PR DESCRIPTION
From the [Nim Manual][1]:

>A directory can also be a so-called "pseudo directory". They can be used to avoid ambiguity when there are multiple modules with the same path.
>
>There are two pseudo directories:
>
>1. `std`: The `std` pseudo directory is the abstract location of Nim's standard library. For example, the syntax `import std / strutils` is used to unambiguously refer to the standard library's strutils` module.
>2. `pkg`: The `pkg` pseudo directory is used to unambiguously refer to a Nimble package. However, for technical details that lie outside the scope of this document, its semantics are: *Use the search path to look for module name but ignore the standard library locations*. In other words, it is the opposite of `std`.
>
>It is recommended and preferred but not currently enforced that all stdlib module imports include the std/ "pseudo directory" as part of the import name.

[1]: https://github.com/nim-lang/Nim/blob/b82b5d44afbd/doc/manual.md#pseudo-importinclude-paths

Refs: #408