### PR TITLE
exercises: examples: use `func` where possible

### DIFF
--- a/exercises/practice/anagram/.meta/example.nim
+++ b/exercises/practice/anagram/.meta/example.nim
@@ -7,12 +7,12 @@ type TAnagram = tuple
 func isAnagramTo(a, b: TAnagram): bool =
   a.chars == b.chars and cmpIgnoreCase(a.word, b.word) != 0
 
-proc anagram(word: string): TAnagram =
+func anagram(word: string): TAnagram =
   var chars = toSeq(word.toLowerAscii().items)
   sort(chars, cmp[char])
   (word, chars)
 
-proc detectAnagrams*(word: string, candidates: seq[string]): seq[string] =
+func detectAnagrams*(word: string, candidates: seq[string]): seq[string] =
   ## Returns a sequence of those `candidates` that are anagrams of `word`.
   ##
   ## .. code-block:: nimrod

--- a/exercises/practice/armstrong-numbers/.meta/example.nim
+++ b/exercises/practice/armstrong-numbers/.meta/example.nim
@@ -1,6 +1,6 @@
 import math, strutils
 
-proc isArmstrongNumber*(input: int): bool =
+func isArmstrongNumber*(input: int): bool =
   let stringNumber = $input
   let numberLength = len(stringNumber).toFloat
 

--- a/exercises/practice/atbash-cipher/.meta/example.nim
+++ b/exercises/practice/atbash-cipher/.meta/example.nim
@@ -5,7 +5,7 @@ const
   Cipher = "zyxwvutsrqponmlkjihgfedcba"
 
 
-proc group(s: string, digits = 5): string =
+func group(s: string, digits = 5): string =
   result = ""
   var c = 0
   for item in s:
@@ -15,14 +15,14 @@ proc group(s: string, digits = 5): string =
     result.add(item)
     inc(c)
 
-proc clean(phrase: string): seq[char] =
+func clean(phrase: string): seq[char] =
   phrase.toLowerAscii.filterIt(it.isAlphaNumeric)
 
-proc convert(c: char, fromInput: string, toInput: string): char =
+func convert(c: char, fromInput: string, toInput: string): char =
   if c.isAlphaAscii: toInput[fromInput.find(c)] else: c
 
-proc encode*(phrase: string): string =
+func encode*(phrase: string): string =
   phrase.clean.mapIt(it.convert(Plain, Cipher)).join("").group
 
-proc decode*(phrase: string): string =
+func decode*(phrase: string): string =
   phrase.clean.mapIt(it.convert(Cipher, Plain)).join("")

--- a/exercises/practice/binary/.meta/example.nim
+++ b/exercises/practice/binary/.meta/example.nim
@@ -1,7 +1,7 @@
 from algorithm import reversed
 from strutils import allCharsInSet
 
-proc binary*(input: string): int {.raises: [ValueError]} =
+func binary*(input: string): int {.raises: [ValueError]} =
   if not input.allCharsInSet({'0', '1'}):
     raise newException(ValueError, "not binary")
   else:

--- a/exercises/practice/bob/.meta/example.nim
+++ b/exercises/practice/bob/.meta/example.nim
@@ -1,13 +1,13 @@
 from strutils import endsWith, strip
 from unicode import isLower, isUpper, isWhiteSpace, runes
 
-proc isSilence(s: string): bool =
+func isSilence(s: string): bool =
   for r in runes(s):
     if not isWhiteSpace(r):
       return false
   return true
 
-proc isYelling(s: string): bool =
+func isYelling(s: string): bool =
   var nUpperRunes = 0
   for r in runes(s):
     if isLower(r):
@@ -16,7 +16,7 @@ proc isYelling(s: string): bool =
       inc(nUpperRunes)
   return nUpperRunes > 0
 
-proc isQuestion(s: string): bool =
+func isQuestion(s: string): bool =
   return s.strip().endsWith("?")
 
 func hey*(msg: string): string =

--- a/exercises/practice/collatz-conjecture/.meta/example.nim
+++ b/exercises/practice/collatz-conjecture/.meta/example.nim
@@ -1,4 +1,4 @@
-proc steps*(number: int): int =
+func steps*(number: int): int =
   if (number < 1):
     raise newException(ValueError, "Only positive integers are allowed")
 

--- a/exercises/practice/difference-of-squares/.meta/example.nim
+++ b/exercises/practice/difference-of-squares/.meta/example.nim
@@ -1,14 +1,14 @@
-proc `**`(base, exponent: int): int =
+func `**`(base, exponent: int): int =
   var power = 1
   for i in 1..exponent:
     power *= base
   power
 
-proc squareOfSum*(n: int): int =
+func squareOfSum*(n: int): int =
   (n * (n + 1) div 2) ** 2
 
-proc sumOfSquares*(n: int): int =
+func sumOfSquares*(n: int): int =
   (n * (n + 1) * ((2 * n) + 1)) div 6
 
-proc difference*(n: int): int =
+func difference*(n: int): int =
   abs(sumOfSquares(n) - squareOfSum(n))

--- a/exercises/practice/grains/.meta/example.nim
+++ b/exercises/practice/grains/.meta/example.nim
@@ -1,8 +1,8 @@
-proc onSquare*(number: int): uint64 =
+func onSquare*(number: int): uint64 =
   if (number <= 0 or number > 64):
     raise newException(ValueError, "square must be between 1 and 64")
 
   1'u64 shl (number.uint64 - 1'u64)
 
-proc total*: uint64 =
+func total*: uint64 =
   not 0'u64

--- a/exercises/practice/hamming/.meta/example.nim
+++ b/exercises/practice/hamming/.meta/example.nim
@@ -1,8 +1,8 @@
 import sequtils
 
-proc isDifferent(pair: tuple[a, b: char]): bool = pair.a != pair.b
+func isDifferent(pair: tuple[a, b: char]): bool = pair.a != pair.b
 
-proc distance*(strand1, strand2: string): int =
+func distance*(strand1, strand2: string): int =
   if len(strand1) != len(strand2):
     raise newException(ValueError, "Invalid nucleotide")
   len(filter(zip(toSeq(strand1.items), toSeq(strand2.items)), isDifferent))

--- a/exercises/practice/hello-world/.meta/example.nim
+++ b/exercises/practice/hello-world/.meta/example.nim
@@ -1,2 +1,2 @@
-proc hello*: string =
+func hello*: string =
   "Hello, World!"

--- a/exercises/practice/isogram/.meta/example.nim
+++ b/exercises/practice/isogram/.meta/example.nim
@@ -1,5 +1,5 @@
 import sequtils, sets, strutils
 
-proc isIsogram*(phrase: string): bool =
+func isIsogram*(phrase: string): bool =
   let charactersLower = phrase.filterIt(it.isAlphaAscii()).mapIt(it.toLowerAscii)
   len(toHashSet(charactersLower)) == len(charactersLower)

--- a/exercises/practice/matching-brackets/.meta/example.nim
+++ b/exercises/practice/matching-brackets/.meta/example.nim
@@ -3,10 +3,10 @@ import deques, sequtils, tables
 const
   lookupTable = {'(': ')', '{': '}', '[': ']'}.toTable
 
-proc hasValue[A, B](t: Table[A, B], value: B): bool =
+func hasValue[A, B](t: Table[A, B], value: B): bool =
   value in toSeq(t.values)
 
-proc isPaired*(value: string): bool =
+func isPaired*(value: string): bool =
   var stack = initDeque[char]()
 
   for item in value:

--- a/exercises/practice/nth-prime/.meta/example.nim
+++ b/exercises/practice/nth-prime/.meta/example.nim
@@ -1,6 +1,6 @@
 import math
 
-proc isPrime(n: int): bool =
+func isPrime(n: int): bool =
   if n <= 1:
     return false
 
@@ -20,7 +20,7 @@ iterator primeIter(n: int): int =
       inc countOfPrime
     inc candidate
 
-proc prime*(number: int): int =
+func prime*(number: int): int =
   if number < 1:
     raise newException(ValueError, "there is no zeroth prime")
 

--- a/exercises/practice/pangram/.meta/example.nim
+++ b/exercises/practice/pangram/.meta/example.nim
@@ -3,7 +3,7 @@ import strutils
 const
   asciiLowercase = {'a'..'z'}
 
-proc isPangram*(sentence: string): bool =
+func isPangram*(sentence: string): bool =
   let lowercaseSentence = sentence.toLowerAscii
   for c in asciiLowercase:
     if c notin lowercaseSentence: return false

--- a/exercises/practice/raindrops/.meta/example.nim
+++ b/exercises/practice/raindrops/.meta/example.nim
@@ -1,6 +1,6 @@
 import strutils
 
-proc convert*(sound: int): string =
+func convert*(sound: int): string =
   var raindrops = ""
 
   if (sound mod 3) == 0:

--- a/exercises/practice/reverse-string/.meta/example.nim
+++ b/exercises/practice/reverse-string/.meta/example.nim
@@ -1,4 +1,4 @@
-proc reverse*(value: string): string =
+func reverse*(value: string): string =
   result = newString(value.len)
   for index, letter in value:
     result[value.high - index] = letter

--- a/exercises/practice/rna-transcription/.meta/example.nim
+++ b/exercises/practice/rna-transcription/.meta/example.nim
@@ -1,4 +1,4 @@
-proc toRna*(strand: string): string =
+func toRna*(strand: string): string =
   result = ""
 
   for c in strand:

--- a/exercises/practice/secret-handshake/.meta/example.nim
+++ b/exercises/practice/secret-handshake/.meta/example.nim
@@ -10,10 +10,10 @@ const
   reverseBit = 4
 
 
-proc bitset(input: Natural, position: Natural): bool =
+func bitset(input: Natural, position: Natural): bool =
   (input and 1 shl position) != 0
 
-proc commands*(input: Natural): seq[string] =
+func commands*(input: Natural): seq[string] =
   for index, item in signals:
     if input.bitset(index):
       result.add(item)

--- a/exercises/practice/space-age/.meta/example.nim
+++ b/exercises/practice/space-age/.meta/example.nim
@@ -20,5 +20,5 @@ const times = [
   Neptune: 5200418592.0
 ]
 
-proc age*(planet: Planet, seconds: int64): float =
+func age*(planet: Planet, seconds: int64): float =
   seconds.float / times[planet]

--- a/exercises/practice/sum-of-multiples/.meta/example.nim
+++ b/exercises/practice/sum-of-multiples/.meta/example.nim
@@ -1,6 +1,6 @@
 import sequtils
 
-proc sum*(limit: int, factors: seq[int]): int =
+func sum*(limit: int, factors: seq[int]): int =
   for num in 0..<limit:
     if factors.filterIt(it != 0).anyIt(num mod it == 0):
       result = result + num

--- a/exercises/practice/triangle/.meta/example.nim
+++ b/exercises/practice/triangle/.meta/example.nim
@@ -1,24 +1,24 @@
 import sequtils
 
-proc valid(a, b, c: int): bool =
+func valid(a, b, c: int): bool =
   let greatThenZero = all([a, b, c], proc (x: int): bool = return x > 0)
   let equalityCheck = (a + b >= c) and (a + c >= b) and (b + c >= a)
 
   greatThenZero and equalityCheck
 
-proc isEquilateral*(sides: array[3, int]): bool =
+func isEquilateral*(sides: array[3, int]): bool =
   let a = sides[0]
   let b = sides[1]
   let c = sides[2]
   valid(a, b, c) and all(sides, proc (x: int): bool = return a == x)
 
-proc isIsosceles*(sides: array[3, int]): bool =
+func isIsosceles*(sides: array[3, int]): bool =
   let a = sides[0]
   let b = sides[1]
   let c = sides[2]
   valid(a, b, c) and (a == b or b == c or a == c)
 
-proc isScalene*(sides: array[3, int]): bool =
+func isScalene*(sides: array[3, int]): bool =
   let a = sides[0]
   let b = sides[1]
   let c = sides[2]

--- a/exercises/practice/two-fer/.meta/example.nim
+++ b/exercises/practice/two-fer/.meta/example.nim
@@ -1,2 +1,2 @@
-proc twoFer*(name = "you"): string =
+func twoFer*(name = "you"): string =
   "One for " & name & ", one for me."


### PR DESCRIPTION
Turn every proc into a func where this is possible without making any deeper change. Then, when we do refactor the examples, we'll have a smaller diff and see more clearly the refactors that allow using func.

Remaining procs in the examples:

```console
$ rg --sort path -uu -g 'exercises/practice/*/.meta/example.nim' 'proc'
exercises/practice/acronym/.meta/example.nim
3:proc abbreviate*(phrase: string): string =

exercises/practice/diffie-hellman/.meta/example.nim
19:proc privateKey*(p: int): int =

exercises/practice/gigasecond/.meta/example.nim
3:proc addGigasecond*(date: DateTime): DateTime =

exercises/practice/meetup/.meta/example.nim
7:proc meetup*(y: int, m: int, sched: Schedule, d: WeekDay): string =

exercises/practice/react/.meta/example.nim
35:proc newComputeCell*(dependencies: seq[Cell], compute: ComputeFunc): Cell =
42:proc `value=`*(cell: Cell, val: int) =
51:proc addCallback*(cell: Cell, callback: Callback) =
54:proc removeCallback*(cell: Cell, callback: Callback) =

exercises/practice/robot-name/.meta/example.nim
11:proc shuffledNames: seq[Name] =
34:proc getUnusedName: Name {.inline.} =
40:proc makeRobot*: Robot {.inline.} =
43:proc reset*(r: var Robot) {.inline.} =

exercises/practice/roman-numerals/.meta/example.nim
23:proc roman*(number: int): string =

exercises/practice/run-length-encoding/.meta/example.nim
3:proc encode*(input: string): string =
10:proc decode*(input: string): string =

exercises/practice/scrabble-score/.meta/example.nim
13:proc score*(word: string): int =

exercises/practice/sieve/.meta/example.nim
17:proc primes*(limit: int): seq[int] =

exercises/practice/word-count/.meta/example.nim
7:proc countWords*(sentence: string): TableRef[string, int] =
```

Refs: #408