### PR TITLE
exercises: examples: use `add` instead of `&=`

### DIFF
--- a/exercises/practice/all-your-base/.meta/example.nim
+++ b/exercises/practice/all-your-base/.meta/example.nim
@@ -18,6 +18,6 @@ func convert*(digits: openArray[int], fromBase: int, toBase: int): seq[int] =
   if n == 0:
     return @[0]
   while n > 0:
-    result &= n mod toBase
+    result.add n mod toBase
     n = n div toBase
   result.reverse

--- a/exercises/practice/crypto-square/.meta/example.nim
+++ b/exercises/practice/crypto-square/.meta/example.nim
@@ -4,7 +4,7 @@ func encrypt*(s: string): string =
   var normalized = newStringOfCap(s.len)
   for c in s.toLowerAscii():
     if c in {'a'..'z'} or c in {'0'..'9'}:
-      normalized &= c
+      normalized.add c
 
   let r = normalized.len.float.sqrt.ceil.int
   let c = (normalized.len.float / r.float).round.int
@@ -14,8 +14,8 @@ func encrypt*(s: string): string =
   for s in 0 ..< r:
     var word = ""
     for i in countup(s, normalized.high, r):
-      word &= normalized[i]
+      word.add normalized[i]
 
-    ct &= word
+    ct.add word
 
   result = ct.join(" ")

--- a/exercises/practice/diamond/.meta/example.nim
+++ b/exercises/practice/diamond/.meta/example.nim
@@ -9,13 +9,13 @@ func toDiamond(c: char): seq[string] =
     let i = c.ord - ch.ord
     row[i] = ch
     row[^(i + 1)] = ch
-    result &= row
+    result.add row
   for i in countdown(result.high - 1, 0):
-    result &= result[i]
+    result.add result[i]
 
 func generateDiamonds: seq[string] =
   for c in 'A'..'Z':
-    result &= c.toDiamond.join("\n") & "\n"
+    result.add c.toDiamond.join("\n") & "\n"
 
 const diamonds = generateDiamonds() # Generate all diamonds at compile-time.
 

--- a/exercises/practice/kindergarten-garden/.meta/example.nim
+++ b/exercises/practice/kindergarten-garden/.meta/example.nim
@@ -11,8 +11,8 @@ func plants*(s: string, student: string): seq[Plant] =
 
   for c in theirPlants:
     case c
-    of 'C': result &= Clover
-    of 'G': result &= Grass
-    of 'R': result &= Radishes
-    of 'V': result &= Violets
+    of 'C': result.add Clover
+    of 'G': result.add Grass
+    of 'R': result.add Radishes
+    of 'V': result.add Violets
     else: raise newException(ValueError, "Invalid plant: " & $c)

--- a/exercises/practice/matrix/.meta/example.nim
+++ b/exercises/practice/matrix/.meta/example.nim
@@ -4,12 +4,12 @@ func matrix(s: string): seq[seq[int]] =
   for line in s.splitLines:
     var row = newSeq[int]()
     for n in line.split:
-      row &= n.parseInt
-    result &= row
+      row.add n.parseInt
+    result.add row
 
 func row*(s: string, i: int): seq[int] =
   matrix(s)[i-1]
 
 func column*(s: string, i: int): seq[int] =
   for row in matrix(s):
-    result &= row[i-1]
+    result.add row[i-1]

--- a/exercises/practice/pascals-triangle/.meta/example.nim
+++ b/exercises/practice/pascals-triangle/.meta/example.nim
@@ -3,11 +3,11 @@ func createTriangle(n: int): seq[seq[int]] =
 
   for i in 1 .. n:
     var row = newSeqOfCap[int](n)
-    row &= 1
+    row.add 1
     for j in 1 ..< i:
-      row &= result[i-1][j-1] + result[i-1][j]
-    row &= 1
-    result &= row
+      row.add result[i-1][j-1] + result[i-1][j]
+    row.add 1
+    result.add row
 
 const p = createTriangle(30) # Generate rows of the triangle at compile-time.
 

--- a/exercises/practice/phone-number/.meta/example.nim
+++ b/exercises/practice/phone-number/.meta/example.nim
@@ -1,7 +1,7 @@
 func clean*(s: string): string =
   for c in s:
     if c in {'0'..'9'}:
-      result &= c
+      result.add c
 
   if result.len == 11 and result[0] == '1':
     result = result[1 .. ^1]

--- a/exercises/practice/prime-factors/.meta/example.nim
+++ b/exercises/practice/prime-factors/.meta/example.nim
@@ -5,6 +5,6 @@ func primeFactors*(n: int64): seq[int] =
   while n > 1:
     while n mod d == 0:
       n = n div d
-      result &= d
+      result.add d
 
     inc d

--- a/exercises/practice/proverb/.meta/example.nim
+++ b/exercises/practice/proverb/.meta/example.nim
@@ -5,6 +5,6 @@ func recite*(s: openArray[string]): string =
     return
 
   for i in 0 .. s.high - 1:
-    result &= &"For want of a {s[i]} the {s[i+1]} was lost.\n"
+    result.add &"For want of a {s[i]} the {s[i+1]} was lost.\n"
 
-  result &= &"And all for the want of a {s[0]}."
+  result.add &"And all for the want of a {s[0]}."

--- a/exercises/practice/rna-transcription/.meta/example.nim
+++ b/exercises/practice/rna-transcription/.meta/example.nim
@@ -4,12 +4,12 @@ proc toRna*(strand: string): string =
   for c in strand:
     case c
     of 'A':
-      result &= 'U'
+      result.add 'U'
     of 'G':
-      result &= 'C'
+      result.add 'C'
     of 'C':
-      result &= 'G'
+      result.add 'G'
     of 'T':
-      result &= 'A'
+      result.add 'A'
     else:
       raise newException(ValueError, "Invalid nucleotide")

--- a/exercises/practice/rotational-cipher/.meta/example.nim
+++ b/exercises/practice/rotational-cipher/.meta/example.nim
@@ -1,6 +1,6 @@
 func toStr(s: set[char]): string =
   for c in s:
-    result &= c
+    result.add c
 
 const alphabetLower = {'a'..'z'}.toStr # Generate alphabet at compile-time.
 const alphabetUpper = {'A'..'Z'}.toStr
@@ -8,8 +8,8 @@ const alphabetUpper = {'A'..'Z'}.toStr
 func rotate*(s: string, n: Natural): string =
   for c in s:
     if c in {'a'..'z'}:
-      result &= alphabetLower[(c.ord + (n mod 26) - 'a'.ord) mod 26]
+      result.add alphabetLower[(c.ord + (n mod 26) - 'a'.ord) mod 26]
     elif c in {'A'..'Z'}:
-      result &= alphabetUpper[(c.ord + (n mod 26) - 'A'.ord) mod 26]
+      result.add alphabetUpper[(c.ord + (n mod 26) - 'A'.ord) mod 26]
     else:
-      result &= c
+      result.add c

--- a/exercises/practice/saddle-points/.meta/example.nim
+++ b/exercises/practice/saddle-points/.meta/example.nim
@@ -13,4 +13,4 @@ func saddlePoints*(matrix: seq[seq[int]]): seq[tuple[r, c: int]] =
     let rowMax = row.max
     for c, _ in row:
       if rowMax == colMins[c]:
-        result &= (r+1, c+1)
+        result.add (r+1, c+1)

--- a/exercises/practice/scale-generator/.meta/example.nim
+++ b/exercises/practice/scale-generator/.meta/example.nim
@@ -15,4 +15,4 @@ func scale*(tonic: string, intervals = defaultIntervals): seq[string] =
   result = @[tonicCapitalized]
   for c in intervals:
     i += semitones[c]
-    result &= chromatic[i mod 12]
+    result.add chromatic[i mod 12]

--- a/exercises/practice/series/.meta/example.nim
+++ b/exercises/practice/series/.meta/example.nim
@@ -3,4 +3,4 @@ func slices*(s: string, n: int): seq[string] =
     raise newException(ValueError, "Invalid slice length: " & $n)
 
   for i in 0 .. s.len-n:
-    result &= s[i ..< i+n]
+    result.add s[i ..< i+n]

--- a/exercises/practice/sieve/.meta/example.nim
+++ b/exercises/practice/sieve/.meta/example.nim
@@ -17,4 +17,4 @@ let p = eratosthenes(1e6.int)
 proc primes*(limit: int): seq[int] =
   for i in 2 .. limit:
     if p[i]:
-      result &= i
+      result.add i

--- a/exercises/practice/twelve-days/.meta/example.nim
+++ b/exercises/practice/twelve-days/.meta/example.nim
@@ -28,15 +28,15 @@ func generateVerses: tuple[song: string, indices: DayArray[int]] =
   ##   `indices`: the index in `song` of the first character for each verse.
   for n in nth.low .. nth.high:
     result.indices[n] = result.song.len
-    result.song &= &"On the {nth[n]} day of Christmas my true love gave to me: "
+    result.song.add &"On the {nth[n]} day of Christmas my true love gave to me: "
     for i in countdown(n, 1):
       case i
       of 3..12:
-        result.song &= &"{gifts[i]}, "
+        result.song.add &"{gifts[i]}, "
       of 2:
-        result.song &= &"{gifts[i]}, and "
+        result.song.add &"{gifts[i]}, and "
       of 1:
-        result.song &= &"{gifts[i]}.\n\n"
+        result.song.add &"{gifts[i]}.\n\n"
 
 const (song, indices) = generateVerses() # Generate the lyrics at compile-time.
 


### PR DESCRIPTION
Reduce the diff size in upcoming refactors of the examples.

The `&=` operator is an [alias for `add`][1]. The latter is more common.

[1]: https://github.com/nim-lang/Nim/blob/b82b5d44afbd/lib/system.nim#L2305-L2309

Refs: #408