### PR TITLE
exercises(scale-generator): make second parameter required

### DIFF
--- a/exercises/practice/scale-generator/.meta/example.nim
+++ b/exercises/practice/scale-generator/.meta/example.nim
@@ -5,9 +5,8 @@ const
   chromaticFlats = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"]
   flatKeys = ["F", "Bb", "Eb", "Ab", "Db", "Gb", "d", "g", "c", "f", "bb", "eb"].toHashSet
   semitones = {'m': 1, 'M': 2, 'A': 3}.toTable
-  defaultIntervals = "m".repeat(11)
 
-func scale*(tonic: string, intervals = defaultIntervals): seq[string] =
+func scale*(tonic: string, intervals: string): seq[string] =
   let chromatic = if tonic in flatKeys: chromaticFlats else: chromaticSharps
   let tonicCapitalized = tonic.capitalizeAscii()
   var i = chromatic.find(tonicCapitalized)

--- a/exercises/practice/scale-generator/scale_generator.nim
+++ b/exercises/practice/scale-generator/scale_generator.nim
@@ -1,6 +1,2 @@
-import std/strutils
-
-const chromaticIntervals = "m".repeat(11)
-
-proc scale*(tonic: string, intervals = chromaticIntervals): seq[string] =
+proc scale*(tonic: string, intervals: string): seq[string] =
   discard

--- a/exercises/practice/scale-generator/test_scale_generator.nim
+++ b/exercises/practice/scale-generator/test_scale_generator.nim
@@ -1,14 +1,16 @@
-import unittest
+import std/[strutils, unittest]
 import scale_generator
 
 suite "Chromatic scales":
+  const chromaticIntervals = "m".repeat(11)
+
   test "chromatic scale with sharps":
-    check scale("C") == @["C", "C#", "D", "D#", "E", "F",
-                          "F#", "G", "G#", "A", "A#", "B"]
+    check scale("C", chromaticIntervals) == @["C", "C#", "D", "D#", "E", "F",
+                                              "F#", "G", "G#", "A", "A#", "B"]
 
   test "chromatic scale with flats":
-    check scale("F") == @["F", "Gb", "G", "Ab", "A", "Bb",
-                          "B", "C", "Db", "D", "Eb", "E"]
+    check scale("F", chromaticIntervals) == @["F", "Gb", "G", "Ab", "A", "Bb",
+                                              "B", "C", "Db", "D", "Eb", "E"]
 
 suite "Scales with specified intervals":
   test "simple major scale":


### PR DESCRIPTION
Then all the intervals can appear in the test file, and the stub is simpler.

And conceptually, there's wasn't much justification for the chromatic scale being "the default scale" when we call the `scale` procedure.

Closes: #493

---

Follow-up from https://github.com/exercism/nim/commit/06572c04af156bf62b3dc80183e78b75a9e25f5d.