### PR TITLE
exercises: sync docs for 5 exercises

### DIFF
--- a/exercises/practice/binary-search/.docs/instructions.md
+++ b/exercises/practice/binary-search/.docs/instructions.md
@@ -11,7 +11,7 @@ Binary search only works when a list has been sorted.
 
 The algorithm looks like this:
 
-- Find the middle element of a sorted list and compare it with the item we're looking for.
+- Find the middle element of a *sorted* list and compare it with the item we're looking for.
 - If the middle element is our item, then we're done!
 - If the middle element is greater than our item, we can eliminate that element and all the elements **after** it.
 - If the middle element is less than our item, we can eliminate that element and all the elements **before** it.

--- a/exercises/practice/darts/.docs/instructions.md
+++ b/exercises/practice/darts/.docs/instructions.md
@@ -12,7 +12,7 @@ In our particular instance of the game, the target rewards 4 different amounts o
 - If the dart lands in the inner circle of the target, player earns 10 points.
 
 The outer circle has a radius of 10 units (this is equivalent to the total radius for the entire target), the middle circle a radius of 5 units, and the inner circle a radius of 1.
-Of course, they are all centered at the same point (that is, the circles are [concentric][] defined by the coordinates (0, 0).
+Of course, they are all centered at the same point — that is, the circles are [concentric][] defined by the coordinates (0, 0).
 
 Write a function that given a point in the target (defined by its [Cartesian coordinates][cartesian-coordinates] `x` and `y`, where `x` and `y` are [real][real-numbers]), returns the correct amount earned by a dart landing at that point.
 

--- a/exercises/practice/pangram/.docs/instructions.md
+++ b/exercises/practice/pangram/.docs/instructions.md
@@ -5,4 +5,4 @@ Your task is to figure out if a sentence is a pangram.
 A pangram is a sentence using every letter of the alphabet at least once.
 It is case insensitive, so it doesn't matter if a letter is lower-case (e.g. `k`) or upper-case (e.g. `K`).
 
-For this exercise we only use the basic letters used in the English alphabet: `a` to `z`.
+For this exercise, a sentence is a pangram if it contains each of the 26 letters in the English alphabet.

--- a/exercises/practice/secret-handshake/.docs/instructions.md
+++ b/exercises/practice/secret-handshake/.docs/instructions.md
@@ -43,5 +43,6 @@ jump, double blink
 
 ~~~~exercism/note
 If you aren't sure what binary is or how it works, check out [this binary tutorial][intro-to-binary].
+
 [intro-to-binary]: https://medium.com/basecs/bits-bytes-building-with-binary-13cb4289aafa
 ~~~~

--- a/exercises/practice/two-fer/.docs/instructions.md
+++ b/exercises/practice/two-fer/.docs/instructions.md
@@ -17,9 +17,9 @@ One for you, one for me.
 
 Here are some examples:
 
-|Name    |Dialogue
-|:-------|:------------------
-|Alice   |One for Alice, one for me.
-|Bohdan  |One for Bohdan, one for me.
-|        |One for you, one for me.
-|Zaphod  |One for Zaphod, one for me.
+| Name   | Dialogue                    |
+| :----- | :-------------------------- |
+| Alice  | One for Alice, one for me.  |
+| Bohdan | One for Bohdan, one for me. |
+|        | One for you, one for me.    |
+| Zaphod | One for Zaphod, one for me. |


### PR DESCRIPTION
Reflect some minor upstream changes:

- https://github.com/exercism/problem-specifications/commit/552598583f5b
- https://github.com/exercism/problem-specifications/commit/f77112974626
- https://github.com/exercism/problem-specifications/commit/fc0e70d3c4b4
- https://github.com/exercism/problem-specifications/commit/a9f93a78db8f
- https://github.com/exercism/problem-specifications/commit/952db56a51f1

---

I don't think these changes need to be a high priority Exercism-wide. But I'll sync them here, just to keep the configlet output short for myself.

With this PR, the remaining out-of-sync data on the Nim track is:

```console
$ git rev-parse --short HEAD
30766b6
$ bin/configlet sync
Updating cached 'problem-specifications' data...
Checking exercises...
[warn] docs: instructions unsynced: largest-series-product
[warn] docs: introduction missing: largest-series-product
[warn] docs: instructions unsynced: linked-list
[warn] docs: introduction missing: linked-list
[warn] docs: instructions unsynced: rna-transcription
[warn] docs: introduction missing: rna-transcription
[warn] docs: instructions unsynced: saddle-points
[warn] docs: introduction missing: saddle-points
[warn] some exercises have unsynced docs
```