### PR TITLE
.github: bump Nim from 1.6.10 to 2.0.0

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -7,13 +7,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - nim: '1.6.10'
+          - nim: '2.0.0'
             os: linux
 
-          - nim: '1.6.10'
+          - nim: '2.0.0'
             os: macOS
 
-          - nim: '1.6.10'
+          - nim: '2.0.0'
             os: windows
 
           - nim: devel

--- a/.github/workflows/uuids.yml
+++ b/.github/workflows/uuids.yml
@@ -5,7 +5,7 @@ jobs:
   check_uuids:
     runs-on: ubuntu-22.04
     env:
-      NIM_VERSION: '1.6.10'
+      NIM_VERSION: '2.0.0'
 
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3


### PR DESCRIPTION
Before this PR, the track CI used Nim versions 1.6.0, 1.6.10, and devel. Update the Nim 1.6.10 jobs to Nim 2.0.0.

Note that the track docs still say:

https://github.com/exercism/nim/blob/cc7211f8b9ebb9f7e8eea869aac1e081d8dde74b/docs/INSTALLATION.md#L5

See the Nim 2.0 [blog post][1] and [changelog][2].

[1]: https://nim-lang.org/blog/2023/08/01/nim-v20-released.html
[2]: https://github.com/nim-lang/Nim/blob/a488067a4130f029000be4550a0fb1b39e0e9e7c/changelogs/changelog_2_0_0_details.md

Closes: #524

---

This bump should be easy, because CI already tested Nim devel.

Previous bump: https://github.com/exercism/nim/pull/441