### PR TITLE
.github: bump iffy/install-nim from 4.7.2 to 4.7.3

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install Nim (non-devel)
         if: matrix.nim != 'devel'
-        uses: iffy/install-nim@bea090a732f3e1918187bac8dd05ab1ab87a569f
+        uses: iffy/install-nim@ac410af52523f06e0fa037ee81d06ead7b95692c
         with:
           version: "binary:${{ matrix.nim }}"
         env:

--- a/.github/workflows/uuids.yml
+++ b/.github/workflows/uuids.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Install Nim
       if: steps.cache-uuids.outputs.cache-hit != 'true'
-      uses: iffy/install-nim@bea090a732f3e1918187bac8dd05ab1ab87a569f
+      uses: iffy/install-nim@ac410af52523f06e0fa037ee81d06ead7b95692c
       with:
         version: "binary:${{ env.NIM_VERSION }}"
       env:


### PR DESCRIPTION
This adds support for Nim 2.0.

See the [changes since the previous release][1].

[1]: https://github.com/iffy/install-nim/compare/bea090a732f3...ac410af52523

Refs: #524