### PR TITLE
.github(dependabot): change interval from daily to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,5 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
+      time: '07:00'


### PR DESCRIPTION
Rationale:

- I'd prefer to get low-priority dependabot notifications only once per month, rather than potentially any time of any day. I do actually review them - I don't blindly merge.
- This decreases churn and the total number of dependabot PRs, because dependencies are sometimes bumped more than once a month.
- When the bump is not security-critical, it's good to wait a little in case there are problems with the new version that require a quick follow-up release.
- This repo does not build some user-facing asset, so the drawbacks of slower updates to our GitHub Actions dependencies are minimal.
- If there's some dependency that we need bumped faster, then we can always do it manually (or tell dependabot to create a PR).
- We already have the monthly interval in some other Exercism repos, e.g. [nim-test-runner](https://github.com/exercism/nim-test-runner/blob/72037075eef1f6399746337d87eb412777168f6a/.github/dependabot.yml), and it helps.

The actions that we currently use in this repo:

```console
$ git rev-parse --short HEAD
1a470ee6
$ git grep 'uses:' -- '.github/workflows/*yml' | cut -d':' -f4 | sort | uniq | cut -d ' ' -f2
actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
alaviss/setup-nim@f81f2a6d1505ab32f440ec9d8adbb81e949d3bf0
DavidAnson/markdownlint-cli2-action@ed4dec634fd2ef689c7061d5647371d8248064f1
exercism/github-actions/.github/workflows/community-contributions.yml@main
exercism/github-actions/.github/workflows/configlet.yml@main
exercism/github-actions/.github/workflows/labels.yml@main
iffy/install-nim@96e44cd5d6df83f65cd844a8631e8301944bc958
ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
```