### PR TITLE
.github(dependabot): specify commit message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     schedule:
       interval: 'monthly'
       time: '07:00'
+    commit-message:
+      prefix: '.github'


### PR DESCRIPTION
Before this PR, dependabot always prefixed commit messages (and PR titles) with

```text
build(deps):
```

despite claiming to determine the prefix from the git history. Explicitly tell dependabot to prefix with:

```
.github:
```

which is the prevailing style in this repo:

```console
$ git log --oneline | grep -o '\.github.*'
.github(dependabot): change interval from daily to monthly
.github: bump iffy/install-nim from 4.7.3 to 5.0.0 (#535)
.github: bump markdownlint-cli2-action from 12.0.0 to 13.0.0 (#534)
.github: bump actions/cache from 3.3.1 to 3.3.2 (#533)
.github: bump actions/checkout from 3.6.0 to 4.0.0 (#532)
.github: bump markdownlint-cli2-action from 10.0.1 to 11.0.0 (#521)
.github: bump actions/checkout from 3.5.0 to 3.6.0 (#530)
.github(org-wide-files-config): enable configlet fmt (#529)
.github: bump Nim from 1.6.10 to 2.0.0 (#525)
.github: bump iffy/install-nim from 4.7.2 to 4.7.3 (#526)
.github: bump markdownlint-cli2-action from 10.0.0 to 10.0.1 (#520)
.github: bump markdownlint-cli2-action from 9.0.0 to 10.0.0 (#519)
.github: bump actions/checkout from 3.4.0 to 3.5.0 (#509)
.github: bump actions/checkout from 3.3.0 to 3.4.0 (#507)
.github: bump iffy/install-nim from 4.6.1 to 4.7.0 (#504)
.github: bump actions/cache from 3.3.0 to 3.3.1 (#503)
.github: bump actions/cache from 3.2.6 to 3.3.0 (#502)
.github: bump actions/cache from 3.2.5 to 3.2.6 (#485)
.github: bump actions/cache from 3.2.4 to 3.2.5 (#482)
.github: bump ludeeus/action-shellcheck from 1.1.0 to 2.0.0 (#481)
.github: bump actions/cache from 3.2.3 to 3.2.4 (#480)
.github, check_exercises: turn styleCheck hints into errors (#465)
.github: enable `configlet fmt` in CI (#472)
.github, docs: bump minimum Nim version from 1.0.0 to 1.6.0 (#459)
.github: bump actions/cache from 3.2.2 to 3.2.3 (#455)
.github: bump actions/checkout from 3.2.0 to 3.3.0 (#454)
.github: bump markdownlint-cli2-action from 8.0.0 to 9.0.0 (#453)
.github: bump actions/cache from 3.2.1 to 3.2.2 (#452)
.github(pause-community-contributions): add custom token (#448)
.github: bump markdownlint-cli2-action from 7.0.0 to 8.0.0 (#446)
.github(autoresponder): use shared workflow (#445)
.github: add autoresponder for pausing community contributions (#444)
.github(workflows): bump Nim from 1.6.8 to 1.6.10 (#441)
.github(workflows): bump `iffy/install-nim` from 4.4.0 to 4.5.0 (#442)
.github(workflows): pin Nim stable versions at 1.6.8 and 1.0.10 (#432)
.github(workflows): move to `iffy/install-nim` 4.4.0 (#431)
.github(workflows): pin `jiro4989/setup-nim-action` to 1.3.63 (#430)
.github(workflows): pin `actions/cache` to 3.0.11 (#429)
.github(workflows): pin `actions/checkout` to 3.1.0 (#428)
.github: add markdownlint workflow (#415)
.github(workflows): bump Windows from 2019 to 2022 (#426)
.github(workflows): bump macOS from 10.15 to 12 (#425)
.github(workflows): bump Ubuntu from 20.04 to 22.04 (#424)
.github: add script and workflow to lint whitespace (#413)
.github(workflows): add shellcheck workflow (#412)
.github/labels.yml` file (#303)
```

```console
$ git log --oneline | grep -o 'build.*:.*'
build(deps): bump DavidAnson/markdownlint-cli2-action (#531)
build(deps): bump iffy/install-nim from 4.7.0 to 4.7.2 (#522)
build(deps): bump iffy/install-nim from 4.5.0 to 4.6.1 (#484)
build(deps): bump actions/cache from 3.2.0 to 3.2.1 (#451)
build(deps): bump actions/cache from 3.0.11 to 3.2.0 (#450)
build(deps): bump actions/checkout from 3.1.0 to 3.2.0 (#449)
````