### PR TITLE
Add exercise two-bucket

### DIFF
--- a/config.json
+++ b/config.json
@@ -979,6 +979,14 @@
           "events",
           "reactive_programming"
         ]
+      },
+      {
+        "slug": "two-bucket",
+        "name": "Two Bucket",
+        "uuid": "7bd03415-9b80-455c-a41c-3de292595fcd",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
       }
     ]
   },

--- a/exercises/practice/two-bucket/.docs/instructions.md
+++ b/exercises/practice/two-bucket/.docs/instructions.md
@@ -1,0 +1,46 @@
+# Instructions
+
+Given two buckets of different size and which bucket to fill first, determine how many actions are required to measure an exact number of liters by strategically transferring fluid between the buckets.
+
+There are some rules that your solution must follow:
+
+- You can only do one action at a time.
+- There are only 3 possible actions:
+  1. Pouring one bucket into the other bucket until either:
+     a) the first bucket is empty
+     b) the second bucket is full
+  2. Emptying a bucket and doing nothing to the other.
+  3. Filling a bucket and doing nothing to the other.
+- After an action, you may not arrive at a state where the starting bucket is empty and the other bucket is full.
+
+Your program will take as input:
+
+- the size of bucket one
+- the size of bucket two
+- the desired number of liters to reach
+- which bucket to fill first, either bucket one or bucket two
+
+Your program should determine:
+
+- the total number of actions it should take to reach the desired number of liters, including the first fill of the starting bucket
+- which bucket should end up with the desired number of liters - either bucket one or bucket two
+- how many liters are left in the other bucket
+
+Note: any time a change is made to either or both buckets counts as one (1) action.
+
+Example:
+Bucket one can hold up to 7 liters, and bucket two can hold up to 11 liters.
+Let's say at a given step, bucket one is holding 7 liters and bucket two is holding 8 liters (7,8).
+If you empty bucket one and make no change to bucket two, leaving you with 0 liters and 8 liters respectively (0,8), that counts as one action.
+Instead, if you had poured from bucket one into bucket two until bucket two was full, resulting in 4 liters in bucket one and 11 liters in bucket two (4,11), that would also only count as one action.
+
+Another Example:
+Bucket one can hold 3 liters, and bucket two can hold up to 5 liters.
+You are told you must start with bucket one.
+So your first action is to fill bucket one.
+You choose to empty bucket one for your second action.
+For your third action, you may not fill bucket two, because this violates the third rule -- you may not end up in a state after any action where the starting bucket is empty and the other bucket is full.
+
+Written with <3 at [Fullstack Academy][fullstack] by Lindsay Levine.
+
+[fullstack]: https://www.fullstackacademy.com/

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "siebenschlaefer"
+  ],
+  "files": {
+    "solution": [
+      "two_bucket.nim"
+    ],
+    "test": [
+      "test_two_bucket.nim"
+    ],
+    "example": [
+      ".meta/example.nim"
+    ]
+  },
+  "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
+  "source": "Water Pouring Problem",
+  "source_url": "https://demonstrations.wolfram.com/WaterPouringProblem/"
+}

--- a/exercises/practice/two-bucket/.meta/example.nim
+++ b/exercises/practice/two-bucket/.meta/example.nim
@@ -1,0 +1,32 @@
+type
+  measureResult* = tuple
+    possible: bool
+    moves: int
+    goalBucket: string
+    otherBucket: int
+
+proc measure*(bucket1, bucket2, goal: int, startBucket: string): measureResult =
+  if startBucket == "two":
+    result = measure(bucket2, bucket1, goal, "one")
+    result.goalBucket = if result.goalBucket == "one": "two" else: "one"
+    return result
+
+  if goal == 0: return (true, 0, "one", 0)
+  if goal == bucket1: return (true, 1, "one", 0)
+  if goal == bucket2: return (true, 2, "two", bucket1)
+
+  var moves, vol1, vol2 = 0
+  while vol1 != 0 or vol2 != bucket2:
+    moves.inc 2
+
+    if vol1 == 0:
+      vol1 = bucket1
+    else:
+      vol2 = 0
+
+    if vol1 + vol2 > bucket2:
+      (vol1, vol2) = (vol1 + vol2 - bucket2, bucket2)
+      if vol1 == goal: return (true, moves, "one", vol2)
+    else:
+      (vol1, vol2) = (0, vol1 + vol2)
+      if vol2 == goal: return (true, moves, "two", vol1)

--- a/exercises/practice/two-bucket/.meta/tests.toml
+++ b/exercises/practice/two-bucket/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[a6f2b4ba-065f-4dca-b6f0-e3eee51cb661]
+description = "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one"
+
+[6c4ea451-9678-4926-b9b3-68364e066d40]
+description = "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two"
+
+[3389f45e-6a56-46d5-9607-75aa930502ff]
+description = "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one"
+
+[fe0ff9a0-3ea5-4bf7-b17d-6d4243961aa1]
+description = "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two"
+
+[0ee1f57e-da84-44f7-ac91-38b878691602]
+description = "Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two"
+
+[eb329c63-5540-4735-b30b-97f7f4df0f84]
+description = "Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two"
+
+[449be72d-b10a-4f4b-a959-ca741e333b72]
+description = "Not possible to reach the goal"
+
+[aac38b7a-77f4-4d62-9b91-8846d533b054]
+description = "With the same buckets but a different goal, then it is possible"
+
+[74633132-0ccf-49de-8450-af4ab2e3b299]
+description = "Goal larger than both buckets is impossible"

--- a/exercises/practice/two-bucket/test_two_bucket.nim
+++ b/exercises/practice/two-bucket/test_two_bucket.nim
@@ -1,0 +1,31 @@
+import unittest
+import two_bucket
+
+suite "two-bucket":
+  test "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one":
+    check measure(3, 5, 1, "one") == (possible: true, moves: 4, goalBucket: "one", otherBucket: 5)
+
+  test "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two":
+    check measure(3, 5, 1, "two") == (possible: true, moves: 8, goalBucket: "two", otherBucket: 3)
+
+  test "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one":
+    check measure(7, 11, 2, "one") == (possible: true, moves: 14, goalBucket: "one", otherBucket: 11)
+
+  test "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two":
+    check measure(7, 11, 2, "two") == (possible: true, moves: 18, goalBucket: "two", otherBucket: 7)
+
+  test "Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two":
+    check measure(1, 3, 3, "two") == (possible: true, moves: 1, goalBucket: "two", otherBucket: 0)
+
+  test "Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two":
+    check measure(2, 3, 3, "one") == (possible: true, moves: 2, goalBucket: "two", otherBucket: 2)
+
+  test "Not possible to reach the goal":
+    check not measure(6, 15, 5, "one").possible
+
+  test "With the same buckets but a different goal, then it is possible":
+    check measure(6, 15, 9, "one") == (possible: true, moves: 10, goalBucket: "two", otherBucket: 0)
+
+  test "Goal larger than both buckets is impossible":
+    check not measure(5, 7, 8, "one").possible
+

--- a/exercises/practice/two-bucket/two_bucket.nim
+++ b/exercises/practice/two-bucket/two_bucket.nim
@@ -1,0 +1,9 @@
+type
+  measureResult* = tuple
+    possible: bool
+    moves: int
+    goalBucket: string
+    otherBucket: int
+
+proc measure*(bucket1, bucket2, goal: int, startBucket: string): measureResult =
+  discard


### PR DESCRIPTION
Please feel free to comment and critique anything.

There has been a discussion in [issue #555](https://github.com/exercism/nim/issues/555#issuecomment-1916147317) about the return type of `measure()`. To keep the discussion focused and have concrete code to talk about I decided to submit this PR now but I'm really open to changes.

This translation uses tuple `(possible: bool, moves: int, goalBucket: string, otherBucket: int)`. For tasks that are possible to solve the function is expected to return a tuple where `possible` is set to `true`, for impossible tasks the function should returns a tuple where the member `possible` is set to `false` (the unmodified default `result` will do) and the values of the other members are ignored by the tests.  

---

I looked at the other tracks and how they do it (as far as I understand these languages):

Three of them cop out: The [Java version](https://github.com/exercism/java/blob/main/exercises/practice/two-bucket/.meta/src/reference/java/TwoBucket.java), [F# version](https://github.com/exercism/fsharp/blob/main/exercises/practice/two-bucket/TwoBucketTests.fs), and [Ruby version](https://github.com/exercism/ruby/blob/main/exercises/practice/two-bucket/two_bucket_test.rb) did omit the tests for the impossible tasks completely.

Two tracks use some sort of compound type with a flag member that indicates impossible tasks:  The [C version](https://github.com/exercism/c/blob/main/exercises/practice/two-bucket/two_bucket.h) and [Go version](https://github.com/exercism/go/blob/main/exercises/practice/two-bucket/two_bucket.go).  
They are similar to my translation (in its current state).

A lot of them use exceptions: The [Python version](https://github.com/exercism/python/blob/main/exercises/practice/two-bucket/.meta/example.py), [C# version](https://github.com/exercism/csharp/blob/main/exercises/practice/two-bucket/.meta/Example.cs), [Crystal version](https://github.com/exercism/crystal/blob/main/exercises/practice/two-bucket/.meta/src/example.cr), [JavaScript version](https://github.com/exercism/javascript/blob/main/exercises/practice/two-bucket/.meta/proof.ci.js), [PHP version](https://github.com/exercism/php/blob/main/exercises/practice/two-bucket/TwoBucketTest.php#L110-L117), [PowerShell version](https://github.com/exercism/powershell/blob/main/exercises/practice/two-bucket/TwoBucket.tests.ps1#L60-L63), [TypeScript version](https://github.com/exercism/typescript/blob/main/exercises/practice/two-bucket/two-bucket.test.ts#L75-L79), [Vim Script version](https://github.com/exercism/vimscript/blob/main/exercises/practice/two-bucket/two_bucket.vader#L37-L41), and [VisualBasic version](https://github.com/exercism/vbnet/blob/main/exercises/practice/two-bucket/TwoBucketTests.vb#L59-L63) use exceptions for impossible tasks.  
The [Lua version]() wants a failed `assert` and the [Wren version](https://github.com/exercism/wren/blob/main/exercises/practice/two-bucket/two-bucket.spec.wren#L35-L39) wants some sort of "abort". I don't know the two languages but I think these are essentially exceptions.

Three use some sort of "Optional": The [Common Lisp version](https://github.com/exercism/common-lisp/blob/main/exercises/practice/two-bucket/two-bucket-test.lisp#L76-L81) and [Elm version](https://github.com/exercism/elm/blob/main/exercises/practice/two-bucket/tests/Tests.elm#L42-L45) require the function to return `NIL`/`Nothing` for impossible tasks.  
The [Rust version](https://github.com/exercism/rust/blob/main/exercises/practice/two-bucket/src/lib.rs#L25) uses an `Option` that is `None` for impossible tasks.

One uses some sort of "Variant": The [jq version](https://github.com/exercism/javascript/blob/main/exercises/practice/two-bucket/.meta/proof.ci.js) requires two different types for possible and impossible tasks.

---

I tried to implement this exercise with an [Object Variant](https://nim-lang.org/docs/manual.html#types-object-variants) but that got more complicated, I had to use a ref type and I couldn't figure out how to write simple tests.  
But probably you folks know how to do that better, right @ynfle?

---

I also tried `Option`.  
That is pretty close to this first version with the `.isPossible` member. I'm not sure which of the two I like more.  
From an educational standpoint it would probably be nice to have an exercise with `Option`.
