### PR TITLE
exercises(roman-numerals): sync tests

### DIFF
--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -84,5 +84,8 @@ description = "3000 is MMM"
 [3bc4b41c-c2e6-49d9-9142-420691504336]
 description = "3001 is MMMI"
 
+[2f89cad7-73f6-4d1b-857b-0ef531f68b7e]
+description = "3888 is MMMDCCCLXXXVIII"
+
 [4e18e96b-5fbb-43df-a91b-9cb511fe0856]
 description = "3999 is MMMCMXCIX"

--- a/exercises/practice/roman-numerals/test_roman_numerals.nim
+++ b/exercises/practice/roman-numerals/test_roman_numerals.nim
@@ -77,5 +77,8 @@ suite "Roman Numerals":
   test "3001 is MMMI":
     check roman(3001) == "MMMI"
 
+  test "3888 is MMMDCCCLXXXVIII":
+    check roman(3888) == "MMMDCCCLXXXVIII"
+
   test "3999 is MMMCMXCIX":
     check roman(3999) == "MMMCMXCIX"


### PR DESCRIPTION
It's slightly easier to review the separate commits here.

The changes:

- Add a test case, reflecting the corresponding [upstream change][1].
- Also reflect the [changed upstream ordering][2], which configlet would not apply when syncing tests for this exercise when all the tests were already implemented.



[1]: https://github.com/exercism/problem-specifications/commit/438990d05c31
[2]: https://github.com/exercism/problem-specifications/commit/2ec5441e326e
