### PR TITLE
fix: update macOs workflow

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -23,7 +23,7 @@ jobs:
             os: linux
 
     name: nim-${{ matrix.nim }}-${{ matrix.os }}
-    runs-on: ${{ matrix.os == 'linux' && 'ubuntu-22.04' || (matrix.os == 'macOS' && 'macos-14' || 'windows-2022') }}
+    runs-on: ${{ matrix.os == 'linux' && 'ubuntu-22.04' || (matrix.os == 'macOS' && 'macos-13' || 'windows-2022') }}
 
     steps:
       - name: Checkout exercism/nim

--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -23,7 +23,7 @@ jobs:
             os: linux
 
     name: nim-${{ matrix.nim }}-${{ matrix.os }}
-    runs-on: ${{ matrix.os == 'linux' && 'ubuntu-22.04' || (matrix.os == 'macOS' && 'macos-12' || 'windows-2022') }}
+    runs-on: ${{ matrix.os == 'linux' && 'ubuntu-22.04' || (matrix.os == 'macOS' && 'macos-14' || 'windows-2022') }}
 
     steps:
       - name: Checkout exercism/nim


### PR DESCRIPTION
GitHub dropped macOS-12 support. Workflow needs updating to 14.

See: https://forum.exercism.org/t/github-actions-runner-breaking-changes-announced/12612