### PR TITLE
.github: bump iffy/install-nim from 5.0.10 to 5.1.0

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install Nim (non-devel)
         if: matrix.nim != 'devel'
-        uses: iffy/install-nim@36ade90cb7e61ea0dc825e0935c17a8cd8e74384
+        uses: iffy/install-nim@0f3350b4052f0906164f934a2e638257341fdff7 # 5.1.0
         with:
           version: "binary:${{ matrix.nim }}"
         env:

--- a/.github/workflows/uuids.yml
+++ b/.github/workflows/uuids.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Install Nim
       if: steps.cache-uuids.outputs.cache-hit != 'true'
-      uses: iffy/install-nim@36ade90cb7e61ea0dc825e0935c17a8cd8e74384
+      uses: iffy/install-nim@0f3350b4052f0906164f934a2e638257341fdff7 # 5.1.0
       with:
         version: "binary:${{ env.NIM_VERSION }}"
       env:


### PR DESCRIPTION
This adds support for Nim 2.2.4. See the [changes][1].

[1]: https://github.com/iffy/install-nim/compare/36ade90cb7e6...0f3350b4052f