### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires Nim 1.6.0 (released 2021-10-19) or later.

--- a/exercises/practice/grade-school/.docs/instructions.append.md
+++ b/exercises/practice/grade-school/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To get the test passing, you are going to need to create some types for your code to work on, you need an object for `School` to hold a sequence of type `Student`, which will be a tuple of `string` and `int` to hold name and grade for the students.
 

--- a/exercises/practice/saddle-points/.docs/instructions.append.md
+++ b/exercises/practice/saddle-points/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 Your implementation can return the coordinates in any order.

--- a/exercises/practice/word-count/.docs/instructions.append.md
+++ b/exercises/practice/word-count/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 The return from `countWords` can be any hash table type with a key of `string` and a value of `int`.
 


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.